### PR TITLE
Fix pom in websubhub publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+target/
+
+.idea/

--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -123,6 +123,7 @@
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.json.simple.parser; version="${com.googlecode.json-simple.wso2.version.range}",


### PR DESCRIPTION
### Proposed changes in this pull request

- `pom.xml` of websubhub publisher was missing export for `carbon.identity.base` bundle, which caused an error when the bundle is loaded. Added the export