### PR TITLE
Change event payload name to "events"

### DIFF
--- a/components/org.wso2.identity.event.common.publisher/org.wso2.identity.event.common.publisher.iml
+++ b/components/org.wso2.identity.event.common.publisher/org.wso2.identity.event.common.publisher.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/SecurityEventTokenPayload.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/SecurityEventTokenPayload.java
@@ -31,7 +31,7 @@ public class SecurityEventTokenPayload {
     private final String aud;
     private final String txn;
     private final String rci;
-    private final Map<String, EventPayload> event;
+    private final Map<String, EventPayload> events;
 
     private SecurityEventTokenPayload(Builder builder) {
 
@@ -41,7 +41,7 @@ public class SecurityEventTokenPayload {
         this.aud = builder.aud;
         this.txn = builder.txn;
         this.rci = builder.rci;
-        this.event = builder.event;
+        this.events = builder.events;
     }
 
     public String getIss() {
@@ -74,9 +74,9 @@ public class SecurityEventTokenPayload {
         return rci;
     }
 
-    public Map<String, EventPayload> getEvent() {
+    public Map<String, EventPayload> getEvents() {
 
-        return event;
+        return events;
     }
 
     public static Builder builder() {
@@ -95,7 +95,7 @@ public class SecurityEventTokenPayload {
         private String aud;
         private String txn;
         private String rci;
-        private Map<String, EventPayload> event;
+        private Map<String, EventPayload> events;
 
         public Builder iss(String iss) {
 
@@ -133,9 +133,9 @@ public class SecurityEventTokenPayload {
             return this;
         }
 
-        public Builder event(Map<String, EventPayload> event) {
+        public Builder events(Map<String, EventPayload> events) {
 
-            this.event = event;
+            this.events = events;
             return this;
         }
 

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
@@ -163,7 +163,7 @@ public class EventPublisherServiceTest {
                 .aud("audience")
                 .txn("transaction")
                 .rci("rci123")
-                .event(eventMap)
+                .events(eventMap)
                 .build();
 
         Assert.assertEquals(payload.getIss(), "issuer");
@@ -172,8 +172,8 @@ public class EventPublisherServiceTest {
         Assert.assertEquals(payload.getAud(), "audience");
         Assert.assertEquals(payload.getTxn(), "transaction");
         Assert.assertEquals(payload.getRci(), "rci123");
-        Assert.assertNotNull(payload.getEvent());
-        Assert.assertEquals(payload.getEvent().get("key1"), eventMap.get("key1"));
+        Assert.assertNotNull(payload.getEvents());
+        Assert.assertEquals(payload.getEvents().get("key1"), eventMap.get("key1"));
     }
 
     @Test
@@ -186,7 +186,7 @@ public class EventPublisherServiceTest {
                 .aud("audience")
                 .txn("transaction")
                 .rci("rci123")
-                .event(null)
+                .events(null)
                 .build();
 
         Assert.assertEquals(payload.getIss(), "issuer");
@@ -195,6 +195,6 @@ public class EventPublisherServiceTest {
         Assert.assertEquals(payload.getAud(), "audience");
         Assert.assertEquals(payload.getTxn(), "transaction");
         Assert.assertEquals(payload.getRci(), "rci123");
-        Assert.assertNull(payload.getEvent());
+        Assert.assertNull(payload.getEvents());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.33</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.82</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.wso2.identity.event.publishers</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <artifactId>identity-event-publishers</artifactId>
 
     <packaging>pom</packaging>
@@ -369,7 +369,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.82</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.111</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

- Change SecurityEventPayload to use "events" field instead of "event". This is part of a migration to new eventing implementation
- Bumped version to 1.0.7
- This a pre-requisite to correctly build https://github.com/wso2-extensions/identity-webhook-event-handlers/pull/11 PR
