### PR TITLE
Add subject to secevent payload

### DIFF
--- a/components/org.wso2.identity.event.common.publisher/pom.xml
+++ b/components/org.wso2.identity.event.common.publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-event-publishers</artifactId>
         <groupId>org.wso2.identity.event.publishers</groupId>
-        <version>1.0.7</version>
+        <version>1.0.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/SecurityEventTokenPayload.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/SecurityEventTokenPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,11 +18,16 @@
 
 package org.wso2.identity.event.common.publisher.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.identity.event.common.publisher.model.common.Subject;
+
 import java.util.Map;
 
 /**
  * Model class for Security Event Token Payload.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SecurityEventTokenPayload {
 
     private final String iss;
@@ -31,6 +36,10 @@ public class SecurityEventTokenPayload {
     private final String aud;
     private final String txn;
     private final String rci;
+
+    @JsonProperty("sub_id")
+    private final Subject subId;
+
     private final Map<String, EventPayload> events;
 
     private SecurityEventTokenPayload(Builder builder) {
@@ -41,6 +50,7 @@ public class SecurityEventTokenPayload {
         this.aud = builder.aud;
         this.txn = builder.txn;
         this.rci = builder.rci;
+        this.subId = builder.subId;
         this.events = builder.events;
     }
 
@@ -79,6 +89,11 @@ public class SecurityEventTokenPayload {
         return events;
     }
 
+    public Subject getSubId() {
+
+        return subId;
+    }
+
     public static Builder builder() {
 
         return new Builder();
@@ -95,6 +110,7 @@ public class SecurityEventTokenPayload {
         private String aud;
         private String txn;
         private String rci;
+        private Subject subId;
         private Map<String, EventPayload> events;
 
         public Builder iss(String iss) {
@@ -136,6 +152,12 @@ public class SecurityEventTokenPayload {
         public Builder events(Map<String, EventPayload> events) {
 
             this.events = events;
+            return this;
+        }
+
+        public Builder subId(Subject subId) {
+
+            this.subId = subId;
             return this;
         }
 

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/ComplexSubject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/ComplexSubject.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.common.publisher.model.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Model Class Implementation for ComplexSubject.
+ */
+public class ComplexSubject extends Subject {
+
+    private static final String COMPLEX = "complex";
+
+    private ComplexSubject() {
+
+    }
+
+    private ComplexSubject(Builder builder) {
+
+        setFormat(COMPLEX);
+        setProperties(Collections.unmodifiableMap(builder.subjectMap));
+    }
+
+    public static Builder builder() {
+
+        return new Builder();
+    }
+
+    /**
+     * Builder class for ComplexSubject.
+     */
+    public static class Builder {
+
+        private static final String TENANT = "tenant";
+        private static final String USER = "user";
+        private static final String SESSION = "session";
+        private static final String APPLICATION = "application";
+        private static final String ORG_UNIT = "org_unit";
+        private static final String GROUP = "group";
+        private final Map<String, SimpleSubject> subjectMap = new HashMap<>();
+
+        private Builder() {
+
+        }
+
+        public Builder tenant(SimpleSubject subject) {
+
+            subjectMap.put(TENANT, subject);
+            return this;
+        }
+
+        public Builder user(SimpleSubject subject) {
+
+            subjectMap.put(USER, subject);
+            return this;
+        }
+
+        public Builder session(SimpleSubject subject) {
+
+            subjectMap.put(SESSION, subject);
+            return this;
+        }
+
+        public Builder application(SimpleSubject subject) {
+
+            subjectMap.put(APPLICATION, subject);
+            return this;
+        }
+
+        public Builder organization(SimpleSubject subject) {
+
+            subjectMap.put(ORG_UNIT, subject);
+            return this;
+        }
+
+        public Builder group(SimpleSubject subject) {
+
+            subjectMap.put(GROUP, subject);
+            return this;
+        }
+
+        public ComplexSubject build() {
+
+            return new ComplexSubject(this);
+        }
+    }
+
+}

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.common.publisher.model.common;
+
+/**
+ * Model Class Implementation for SimpleSubject.
+ */
+public class SimpleSubject extends Subject {
+
+    private static final String EMAIL = "email";
+    private static final String PHONE_NUMBER = "phone_number";
+    private static final String ACCOUNT = "account";
+    private static final String URI = "uri";
+    private static final String ISS_SUB = "iss_sub";
+    private static final String OPAQUE = "opaque";
+    private static final String ID = "id";
+    private static final String DID = "did";
+    private static final String ISS = "iss";
+    private static final String SUB = "sub";
+
+    private static boolean isInvalidValue(String value) {
+
+        return (value == null || value.isEmpty());
+    }
+
+    private SimpleSubject() {
+
+    }
+
+    public static SimpleSubject createEmailSubject(String email) {
+
+        if (isInvalidValue(email)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(EMAIL);
+        subject.addProperty(EMAIL, email);
+        return subject;
+    }
+
+    public static SimpleSubject createPhoneSubject(String phoneNumber) {
+
+        if (isInvalidValue(phoneNumber)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(PHONE_NUMBER);
+        subject.addProperty(PHONE_NUMBER, phoneNumber);
+        return subject;
+    }
+
+    public static SimpleSubject createAccountSubject(String uri) {
+
+        if (isInvalidValue(uri)) {
+            return null;
+        }
+
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(ACCOUNT);
+        subject.addProperty(URI, uri);
+        return subject;
+    }
+
+    public static SimpleSubject createIssSubSubject(String iss, String sub) {
+
+        if (isInvalidValue(iss) || isInvalidValue(sub)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(ISS_SUB);
+        subject.addProperty(ISS, iss);
+        subject.addProperty(SUB, sub);
+        return subject;
+    }
+
+    public static SimpleSubject createOpaqueSubject(String id) {
+
+        if (isInvalidValue(id)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(OPAQUE);
+        subject.addProperty(ID, id);
+        return subject;
+    }
+
+    public static SimpleSubject createDIDSubject(String url) {
+
+        if (isInvalidValue(url)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(DID);
+        subject.addProperty(DID, url);
+        return subject;
+    }
+
+    public static SimpleSubject createURISubject(String uri) {
+
+        if (isInvalidValue(uri)) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(URI);
+        subject.addProperty(URI, uri);
+        return subject;
+    }
+
+}

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/Subject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/Subject.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.common.publisher.model.common;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract Model class for Subject.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class Subject {
+
+    private String format;
+    protected Map<String, Object> properties = new HashMap<>();
+
+    public String getFormat() {
+
+        return format;
+    }
+
+    protected void setFormat(String format) {
+
+        this.format = format;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getProperties() {
+
+        return properties;
+    }
+
+    protected void addProperty(String key, Object value) {
+
+        properties.put(key, value);
+    }
+
+    @JsonAnySetter
+    protected void setProperties(Map<String, Object> properties) {
+
+        this.properties = properties;
+    }
+
+    public Object getProperty(String key) {
+
+        return properties.get(key);
+    }
+
+}

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
@@ -29,8 +29,11 @@ import org.wso2.identity.event.common.publisher.internal.EventPublisherDataHolde
 import org.wso2.identity.event.common.publisher.model.EventContext;
 import org.wso2.identity.event.common.publisher.model.EventPayload;
 import org.wso2.identity.event.common.publisher.model.SecurityEventTokenPayload;
+import org.wso2.identity.event.common.publisher.model.common.SimpleSubject;
+import org.wso2.identity.event.common.publisher.model.common.Subject;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -127,9 +130,9 @@ public class EventPublisherServiceTest {
     }
 
     @Test
-    public void testPublishWithNoPublishers() throws Exception {
+    public void testPublishWithNoPublishers() {
 
-        EventPublisherDataHolder.getInstance().setEventPublishers(Arrays.asList());
+        EventPublisherDataHolder.getInstance().setEventPublishers(Collections.emptyList());
 
         // Call the service method
         eventPublisherService.publish(mockEventPayload, mockEventContext);
@@ -154,7 +157,8 @@ public class EventPublisherServiceTest {
     public void testSecurityEventTokenPayloadBuilder() {
 
         Map<String, EventPayload> eventMap = new HashMap<>();
-        eventMap.put("key1", new EventPayload() { });
+        eventMap.put("key1", new EventPayload() {
+        });
 
         SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
                 .iss("issuer")
@@ -196,5 +200,141 @@ public class EventPublisherServiceTest {
         Assert.assertEquals(payload.getTxn(), "transaction");
         Assert.assertEquals(payload.getRci(), "rci123");
         Assert.assertNull(payload.getEvents());
+    }
+
+    @Test
+    public void testSecurityEventTokenPayloadWithEmptyEvent() {
+
+        SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
+                .iss("issuer")
+                .jti("jti123")
+                .iat(123456789L)
+                .aud("audience")
+                .txn("transaction")
+                .rci("rci123")
+                .events(new HashMap<>())
+                .build();
+
+        Assert.assertEquals(payload.getIss(), "issuer");
+        Assert.assertEquals(payload.getJti(), "jti123");
+        Assert.assertEquals(payload.getIat(), 123456789L);
+        Assert.assertEquals(payload.getAud(), "audience");
+        Assert.assertEquals(payload.getTxn(), "transaction");
+        Assert.assertEquals(payload.getRci(), "rci123");
+        Assert.assertNotNull(payload.getEvents());
+        Assert.assertTrue(payload.getEvents().isEmpty());
+    }
+
+    @Test
+    public void testEventPublisherServiceWithEmptyPublishers() {
+
+        EventPublisherDataHolder.getInstance().setEventPublishers(Collections.emptyList());
+
+        // Call the service method
+        eventPublisherService.publish(mockEventPayload, mockEventContext);
+
+        // Verify no interactions occurred with mock publishers
+        verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
+    }
+
+    @Test
+    public void testEventPublisherServiceWithNullPayload() {
+
+        // Call the service method with null payload
+        eventPublisherService.publish(null, mockEventContext);
+
+        // Verify no interactions occurred with mock publishers
+        verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
+    }
+
+    @Test
+    public void testSecurityEventTokenPayloadWithSubId() {
+
+        Map<String, EventPayload> eventMap = new HashMap<>();
+        eventMap.put("key1", new EventPayload() {
+        });
+
+        Subject subId = SimpleSubject.createOpaqueSubject("subId123");
+
+        SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
+                .iss("issuer")
+                .jti("jti123")
+                .iat(123456789L)
+                .aud("audience")
+                .txn("transaction")
+                .rci("rci123")
+                .subId(subId)
+                .events(eventMap)
+                .build();
+
+        Assert.assertEquals(payload.getIss(), "issuer");
+        Assert.assertEquals(payload.getJti(), "jti123");
+        Assert.assertEquals(payload.getIat(), 123456789L);
+        Assert.assertEquals(payload.getAud(), "audience");
+        Assert.assertEquals(payload.getTxn(), "transaction");
+        Assert.assertEquals(payload.getRci(), "rci123");
+        Assert.assertEquals(payload.getSubId(), subId);
+        Assert.assertNotNull(payload.getEvents());
+        Assert.assertEquals(payload.getEvents().get("key1"), eventMap.get("key1"));
+    }
+
+    @Test
+    public void testSecurityEventTokenPayloadWithNullSubId() {
+
+        Map<String, EventPayload> eventMap = new HashMap<>();
+        eventMap.put("key1", new EventPayload() {
+        });
+
+        SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
+                .iss("issuer")
+                .jti("jti123")
+                .iat(123456789L)
+                .aud("audience")
+                .txn("transaction")
+                .rci("rci123")
+                .subId(null)
+                .events(eventMap)
+                .build();
+
+        Assert.assertEquals(payload.getIss(), "issuer");
+        Assert.assertEquals(payload.getJti(), "jti123");
+        Assert.assertEquals(payload.getIat(), 123456789L);
+        Assert.assertEquals(payload.getAud(), "audience");
+        Assert.assertEquals(payload.getTxn(), "transaction");
+        Assert.assertEquals(payload.getRci(), "rci123");
+        Assert.assertNull(payload.getSubId());
+        Assert.assertNotNull(payload.getEvents());
+        Assert.assertEquals(payload.getEvents().get("key1"), eventMap.get("key1"));
+    }
+
+    @Test
+    public void testSecurityEventTokenPayloadWithEmptySubId() {
+
+        Map<String, EventPayload> eventMap = new HashMap<>();
+        eventMap.put("key1", new EventPayload() {
+        });
+
+        Subject subId = SimpleSubject.createOpaqueSubject("");
+
+        SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
+                .iss("issuer")
+                .jti("jti123")
+                .iat(123456789L)
+                .aud("audience")
+                .txn("transaction")
+                .rci("rci123")
+                .subId(subId)
+                .events(eventMap)
+                .build();
+
+        Assert.assertEquals(payload.getIss(), "issuer");
+        Assert.assertEquals(payload.getJti(), "jti123");
+        Assert.assertEquals(payload.getIat(), 123456789L);
+        Assert.assertEquals(payload.getAud(), "audience");
+        Assert.assertEquals(payload.getTxn(), "transaction");
+        Assert.assertEquals(payload.getRci(), "rci123");
+        Assert.assertEquals(payload.getSubId(), subId);
+        Assert.assertNotNull(payload.getEvents());
+        Assert.assertEquals(payload.getEvents().get("key1"), eventMap.get("key1"));
     }
 }

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.common.publisher;
+
+import org.mockito.Mock;
+import org.testng.annotations.Test;
+import org.wso2.identity.event.common.publisher.model.common.ComplexSubject;
+import org.wso2.identity.event.common.publisher.model.common.SimpleSubject;
+import org.wso2.identity.event.common.publisher.model.common.Subject;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/*
+    Test Class for Subject, SimpleSubject and ComplexSubject Classes
+ */
+public class SubjectModelTest {
+
+    @Mock
+    private SimpleSubject simpleSubject1;
+    @Mock
+    private SimpleSubject simpleSubject2;
+    @Mock
+    private SimpleSubject simpleSubject3;
+    @Mock
+    private SimpleSubject simpleSubject4;
+    @Mock
+    private SimpleSubject simpleSubject5;
+    @Mock
+    private SimpleSubject simpleSubject6;
+
+    @Test
+    public void testSimpleSubjectAccount() {
+
+        Subject simpleSubject = SimpleSubject.createAccountSubject("test");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "account");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("uri"), "test");
+    }
+
+    @Test
+    public void testSimpleSubjectEmail() {
+
+        Subject simpleSubject = SimpleSubject.createEmailSubject("test@example.com");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "email");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("email"), "test@example.com");
+    }
+
+    @Test
+    public void testSimpleSubjectURI() {
+
+        Subject simpleSubject = SimpleSubject.createURISubject("test");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "uri");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("uri"), "test");
+        assertNull(simpleSubject.getProperty("email"));
+    }
+
+    @Test
+    public void testSimpleSubjectPhone() {
+
+        Subject simpleSubject = SimpleSubject.createPhoneSubject("+876756478");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "phone_number");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("phone_number"), "+876756478");
+    }
+
+    @Test
+    public void testSimpleSubjectIssSub() {
+
+        Subject simpleSubject = SimpleSubject.createIssSubSubject("testIss", "testSub");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "iss_sub");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("iss"), "testIss");
+        assertEquals(simpleSubject.getProperty("sub"), "testSub");
+    }
+
+    @Test
+    public void testSimpleSubjectOpaque() {
+
+        Subject simpleSubject = SimpleSubject.createOpaqueSubject("test");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "opaque");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("id"), "test");
+    }
+
+    @Test
+    public void testSimpleSubjectDID() {
+
+        Subject simpleSubject = SimpleSubject.createDIDSubject("test");
+        assertNotNull(simpleSubject);
+        assertEquals(simpleSubject.getFormat(), "did");
+        assertNotNull(simpleSubject.getProperties());
+        assertEquals(simpleSubject.getProperty("did"), "test");
+    }
+
+    @Test
+    public void testComplexSubjectTenant() {
+
+        ComplexSubject subject = ComplexSubject.builder()
+                .tenant(simpleSubject1)
+                .user(simpleSubject2)
+                .session(simpleSubject3)
+                .application(simpleSubject4)
+                .group(simpleSubject5)
+                .organization(simpleSubject6)
+                .build();
+
+        assertNotNull(subject);
+
+        assertEquals(subject.getFormat(), "complex");
+        assertNotNull(subject.getProperties());
+
+        assertEquals(simpleSubject1, subject.getProperty("tenant"));
+        assertEquals(simpleSubject2, subject.getProperty("user"));
+        assertEquals(simpleSubject3, subject.getProperty("session"));
+        assertEquals(simpleSubject4, subject.getProperty("application"));
+        assertEquals(simpleSubject5, subject.getProperty("group"));
+        assertEquals(simpleSubject6, subject.getProperty("organization"));
+
+    }
+
+    @Test
+    public void testComplexSubjectTenantWithNullProperty() {
+
+        ComplexSubject subject = ComplexSubject.builder()
+                .tenant(null)
+                .user(null)
+                .session(null)
+                .application(null)
+                .group(null)
+                .organization(null)
+                .build();
+
+        assertNotNull(subject);
+
+        assertEquals(subject.getFormat(), "complex");
+        assertNotNull(subject.getProperties());
+
+        assertNull(subject.getProperty("tenant"));
+        assertNull(subject.getProperty("user"));
+        assertNull(subject.getProperty("session"));
+        assertNull(subject.getProperty("application"));
+        assertNull(subject.getProperty("group"));
+        assertNull(subject.getProperty("organization"));
+
+    }
+
+}

--- a/components/org.wso2.identity.event.common.publisher/src/test/resources/testng.xml
+++ b/components/org.wso2.identity.event.common.publisher/src/test/resources/testng.xml
@@ -18,9 +18,10 @@
 
 <suite name="EventPublisherServiceTestSuite">
 
-    <test name="EventPublisherServiceTest" preserve-order="true" parallel="false">
+    <test name="EventPublisherServiceTest" parallel="false">
         <classes>
             <class name="org.wso2.identity.event.common.publisher.EventPublisherServiceTest"/>
+            <class name="org.wso2.identity.event.common.publisher.SubjectModelTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-event-publishers</artifactId>
         <groupId>org.wso2.identity.event.publishers</groupId>
-        <version>1.0.7</version>
+        <version>1.0.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -24,7 +24,7 @@ package org.wso2.identity.event.websubhub.publisher.constant;
 public class WebSubHubAdapterConstants {
 
     /**
-     * Configuration related constants
+     * Configuration related constants.
      */
     public static class Config {
         public static final String CONFIG_FILE_NAME = "identity-outbound-adapter.properties";
@@ -32,7 +32,7 @@ public class WebSubHubAdapterConstants {
     }
 
     /**
-    * WebSub Hub Adapter related constants
+    * WebSub Hub Adapter related constants.
     */
     public static class Http {
         public static final String TOPIC_SEPARATOR = "-";

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.wso2.identity.event.publishers</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.7</version>
+    <version>1.0.8-SNAPSHOT</version>
     <artifactId>identity-event-publishers</artifactId>
 
     <packaging>pom</packaging>
@@ -43,7 +43,7 @@
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-event-publishers.git
         </developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-event-publishers.git</connection>
-        <tag>v1.0.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>


### PR DESCRIPTION
### Proposed changes in this pull request

In SSF the subject is defined to be included in the Security Event Payload. This PR introduces the sub_id field to facilitate this and the necessary Subject classes
 - Subject (abstract class)
 - SimpleSubject
 - ComplexSubject