### PR TITLE
Add Aliases Subject Type

### DIFF
--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
@@ -18,7 +18,9 @@
 
 package org.wso2.identity.event.common.publisher.model.common;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Model Class Implementation for SimpleSubject.
@@ -131,6 +133,16 @@ public class SimpleSubject extends Subject {
         if (identifiers == null || identifiers.isEmpty()) {
             return null;
         }
+        for (SimpleSubject identifier : identifiers) {
+            if (identifier.getFormat().equals(ALIASES)) {
+                throw new IllegalArgumentException("Identifier format cannot be " + ALIASES);
+            }
+        }
+        // Remove duplicates
+        Set<SimpleSubject> uniqueIdentifiers = new HashSet<>(identifiers);
+        identifiers.clear();
+        identifiers.addAll(uniqueIdentifiers);
+
         SimpleSubject subject = new SimpleSubject();
         subject.setFormat(ALIASES);
         subject.addProperty(IDENTIFIERS, identifiers);

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
@@ -18,6 +18,9 @@
 
 package org.wso2.identity.event.common.publisher.model.common;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,7 +45,7 @@ public class SimpleSubject extends Subject {
 
     private static boolean isInvalidValue(String value) {
 
-        return (value == null || value.isEmpty());
+        return (StringUtils.isEmpty(value.trim()));
     }
 
     private SimpleSubject() {
@@ -130,7 +133,7 @@ public class SimpleSubject extends Subject {
 
     public static SimpleSubject createAliasesSubject(List<SimpleSubject> identifiers) {
 
-        if (identifiers == null || identifiers.isEmpty()) {
+        if (CollectionUtils.isEmpty(identifiers)) {
             return null;
         }
         for (SimpleSubject identifier : identifiers) {
@@ -138,6 +141,7 @@ public class SimpleSubject extends Subject {
                 throw new IllegalArgumentException("Identifier format cannot be " + ALIASES);
             }
         }
+
         // Remove duplicates
         Set<SimpleSubject> uniqueIdentifiers = new HashSet<>(identifiers);
         identifiers.clear();

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/SimpleSubject.java
@@ -18,6 +18,8 @@
 
 package org.wso2.identity.event.common.publisher.model.common;
 
+import java.util.List;
+
 /**
  * Model Class Implementation for SimpleSubject.
  */
@@ -33,6 +35,8 @@ public class SimpleSubject extends Subject {
     private static final String DID = "did";
     private static final String ISS = "iss";
     private static final String SUB = "sub";
+    private static final String ALIASES = "aliases";
+    private static final String IDENTIFIERS = "identifiers";
 
     private static boolean isInvalidValue(String value) {
 
@@ -122,4 +126,14 @@ public class SimpleSubject extends Subject {
         return subject;
     }
 
+    public static SimpleSubject createAliasesSubject(List<SimpleSubject> identifiers) {
+
+        if (identifiers == null || identifiers.isEmpty()) {
+            return null;
+        }
+        SimpleSubject subject = new SimpleSubject();
+        subject.setFormat(ALIASES);
+        subject.addProperty(IDENTIFIERS, identifiers);
+        return subject;
+    }
 }

--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/Subject.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/common/Subject.java
@@ -20,7 +20,6 @@ package org.wso2.identity.event.common.publisher.model.common;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +27,6 @@ import java.util.Map;
 /**
  * Abstract Model class for Subject.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class Subject {
 
     private String format;

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
@@ -229,21 +229,14 @@ public class EventPublisherServiceTest {
     public void testEventPublisherServiceWithEmptyPublishers() {
 
         EventPublisherDataHolder.getInstance().setEventPublishers(Collections.emptyList());
-
-        // Call the service method
         eventPublisherService.publish(mockEventPayload, mockEventContext);
-
-        // Verify no interactions occurred with mock publishers
         verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
     }
 
     @Test
     public void testEventPublisherServiceWithNullPayload() {
 
-        // Call the service method with null payload
         eventPublisherService.publish(null, mockEventContext);
-
-        // Verify no interactions occurred with mock publishers
         verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
     }
 

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 /*
     Test Class for Subject, SimpleSubject and ComplexSubject Classes
@@ -176,5 +178,36 @@ public class SubjectModelTest {
         assertEquals(subject.getFormat(), "aliases");
         assertNotNull(subject.getProperties());
         assertEquals(subject.getProperty("identifiers"), subjectList);
+    }
+
+    @Test
+    public void testSimpleSubjectAliasesException() {
+
+        List<SimpleSubject> subjectList1 = new ArrayList<>();
+        subjectList1.add(simpleSubject1);
+        SimpleSubject simpleSubjectAlias = SimpleSubject.createAliasesSubject(subjectList1);
+        List<SimpleSubject> subjectList2 = new ArrayList<>();
+        subjectList2.add(simpleSubjectAlias);
+        subjectList2.add(simpleSubject2);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            SimpleSubject.createAliasesSubject(subjectList2);
+        });
+    }
+
+    @Test
+    public void testSimpleSubjectAliasesDuplicate() {
+
+        List<SimpleSubject> subjectList = new ArrayList<>();
+        subjectList.add(simpleSubject1);
+        subjectList.add(simpleSubject2);
+        subjectList.add(simpleSubject1);
+        SimpleSubject subject = SimpleSubject.createAliasesSubject(subjectList);
+
+        assertNotNull(subject);
+        assertEquals(subject.getFormat(), "aliases");
+        assertNotNull(subject.getProperties());
+        assertTrue(subject.getProperty("identifiers") instanceof List);
+        assertEquals(((List<SimpleSubject>) subject.getProperty("identifiers")).size(), 2);
     }
 }

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/SubjectModelTest.java
@@ -18,11 +18,13 @@
 
 package org.wso2.identity.event.common.publisher;
 
-import org.mockito.Mock;
 import org.testng.annotations.Test;
 import org.wso2.identity.event.common.publisher.model.common.ComplexSubject;
 import org.wso2.identity.event.common.publisher.model.common.SimpleSubject;
 import org.wso2.identity.event.common.publisher.model.common.Subject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -33,18 +35,12 @@ import static org.testng.Assert.assertNull;
  */
 public class SubjectModelTest {
 
-    @Mock
-    private SimpleSubject simpleSubject1;
-    @Mock
-    private SimpleSubject simpleSubject2;
-    @Mock
-    private SimpleSubject simpleSubject3;
-    @Mock
-    private SimpleSubject simpleSubject4;
-    @Mock
-    private SimpleSubject simpleSubject5;
-    @Mock
-    private SimpleSubject simpleSubject6;
+    private SimpleSubject simpleSubject1 = SimpleSubject.createAccountSubject("test");
+    private SimpleSubject simpleSubject2 = SimpleSubject.createOpaqueSubject("test");
+    private SimpleSubject simpleSubject3 = SimpleSubject.createURISubject("test");
+    private SimpleSubject simpleSubject4 = SimpleSubject.createAccountSubject("test");
+    private SimpleSubject simpleSubject5 = SimpleSubject.createAccountSubject("test");
+    private SimpleSubject simpleSubject6 = SimpleSubject.createAccountSubject("test");
 
     @Test
     public void testSimpleSubjectAccount() {
@@ -119,32 +115,6 @@ public class SubjectModelTest {
     }
 
     @Test
-    public void testComplexSubjectTenant() {
-
-        ComplexSubject subject = ComplexSubject.builder()
-                .tenant(simpleSubject1)
-                .user(simpleSubject2)
-                .session(simpleSubject3)
-                .application(simpleSubject4)
-                .group(simpleSubject5)
-                .organization(simpleSubject6)
-                .build();
-
-        assertNotNull(subject);
-
-        assertEquals(subject.getFormat(), "complex");
-        assertNotNull(subject.getProperties());
-
-        assertEquals(simpleSubject1, subject.getProperty("tenant"));
-        assertEquals(simpleSubject2, subject.getProperty("user"));
-        assertEquals(simpleSubject3, subject.getProperty("session"));
-        assertEquals(simpleSubject4, subject.getProperty("application"));
-        assertEquals(simpleSubject5, subject.getProperty("group"));
-        assertEquals(simpleSubject6, subject.getProperty("organization"));
-
-    }
-
-    @Test
     public void testComplexSubjectTenantWithNullProperty() {
 
         ComplexSubject subject = ComplexSubject.builder()
@@ -166,8 +136,45 @@ public class SubjectModelTest {
         assertNull(subject.getProperty("session"));
         assertNull(subject.getProperty("application"));
         assertNull(subject.getProperty("group"));
-        assertNull(subject.getProperty("organization"));
-
+        assertNull(subject.getProperty("org_unit"));
     }
 
+    @Test
+    public void testComplexSubjectTenant() {
+
+        ComplexSubject subject = ComplexSubject.builder()
+                .tenant(simpleSubject1)
+                .user(simpleSubject2)
+                .session(simpleSubject3)
+                .application(simpleSubject4)
+                .group(simpleSubject5)
+                .organization(simpleSubject6)
+                .build();
+
+        assertNotNull(subject);
+
+        assertEquals(subject.getFormat(), "complex");
+        assertNotNull(subject.getProperties());
+
+        assertEquals(simpleSubject1, subject.getProperty("tenant"));
+        assertEquals(simpleSubject2, subject.getProperty("user"));
+        assertEquals(simpleSubject3, subject.getProperty("session"));
+        assertEquals(simpleSubject4, subject.getProperty("application"));
+        assertEquals(simpleSubject5, subject.getProperty("group"));
+        assertEquals(simpleSubject6, subject.getProperty("org_unit"));
+    }
+
+    @Test
+    public void testSimpleSubjectAliases() {
+
+        List<SimpleSubject> subjectList = new ArrayList<>();
+        subjectList.add(simpleSubject1);
+        subjectList.add(simpleSubject2);
+        SimpleSubject subject = SimpleSubject.createAliasesSubject(subjectList);
+
+        assertNotNull(subject);
+        assertEquals(subject.getFormat(), "aliases");
+        assertNotNull(subject.getProperties());
+        assertEquals(subject.getProperty("identifiers"), subjectList);
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Add 'Aliases' Subject Type support for SimpleSubject Class [1]

### Product IS issue

- https://github.com/wso2/product-is/issues/24016

[1] [Aliases Subject Identifier](https://datatracker.ietf.org/doc/html/rfc9493#name-aliases-identifier-format)
