### PR TITLE
Support subscription management

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.webhook.management</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.identity.event.publishers</groupId>
             <artifactId>org.wso2.identity.event.common.publisher</artifactId>
         </dependency>
@@ -126,6 +130,8 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.webhook.management.api;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.json.simple.parser; version="${com.googlecode.json-simple.wso2.version.range}",
                             org.wso2.identity.event.common.publisher;

--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -27,8 +27,8 @@
     <artifactId>org.wso2.identity.event.websubhub.publisher</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
-    <name>WebSub Hub Adapter Module</name>
-    <description>Adapter to integrate with WebSub Hub</description>
+    <name>WebSubHub Adapter Module</name>
+    <description>Adapter to integrate with WebSubHub</description>
 
     <dependencies>
         <dependency>

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/config/WebSubAdapterConfiguration.java
@@ -23,7 +23,7 @@ import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterExcept
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
 
 /**
- * WebSub Adapter Configuration.
+ * WebSubHub Adapter Configuration.
  */
 public class WebSubAdapterConfiguration {
 
@@ -100,9 +100,9 @@ public class WebSubAdapterConfiguration {
     }
 
     /**
-     * Returns the base URL of the WebSub Hub.
+     * Returns the base URL of the WebSubHub.
      *
-     * @return base URL of the WebSub Hub.
+     * @return base URL of the WebSubHub.
      */
     public String getWebSubHubBaseUrl() {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -23,24 +23,32 @@ package org.wso2.identity.event.websubhub.publisher.constant;
  */
 public class WebSubHubAdapterConstants {
 
+    public static final String WEB_SUB_HUB_ADAPTER_NAME = "webSubHubAdapter";
+
     /**
      * Configuration related constants.
      */
     public static class Config {
+
         public static final String CONFIG_FILE_NAME = "identity-outbound-adapter.properties";
-        private Config() {}
+
+        private Config() {
+
+        }
     }
 
     /**
-    * WebSub Hub Adapter related constants.
-    */
+     * WebSub Hub Adapter related constants.
+     */
     public static class Http {
+
         public static final String TOPIC_SEPARATOR = "-";
         public static final String URL_PARAM_SEPARATOR = "&";
         public static final String URL_KEY_VALUE_SEPARATOR = "=";
         public static final String PUBLISH = "publish";
         public static final String HUB_MODE = "hub.mode";
         public static final String HUB_TOPIC = "hub.topic";
+        public static final String HUB_CALLBACK = "hub.callback";
         public static final String HUB_REASON = "hub.reason";
         public static final String HUB_ACTIVE_SUBS = "hub.active.subscribers";
         public static final String REGISTER = "register";
@@ -55,7 +63,12 @@ public class WebSubHubAdapterConstants {
         public static final Integer DEFAULT_HTTP_CONNECTION_REQUEST_TIMEOUT = 300;
         public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS = 20;
         public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE = 2;
-        private Http() {}
+        public static final String SUBSCRIBE = "subscribe";
+        public static final String UNSUBSCRIBE = "unsubscribe";
+
+        private Http() {
+
+        }
     }
 
     /**
@@ -67,19 +80,26 @@ public class WebSubHubAdapterConstants {
                 "WebSub Hub base URL is not configured."),
         ERROR_PUBLISHING_EVENT_INVALID_PAYLOAD("60002", "Invalid payload provided.",
                 "Event payload cannot be processed."),
-        ERROR_NULL_EVENT_PAYLOAD("60003", "Invalid event payload input ", "Event payload input cannot be null."),
-        ERROR_INVALID_EVENT_URI("60004", "Invalid event URI input", "Event URI input cannot be null or empty."),
-        ERROR_INVALID_EVENT_TOPIC("60005", "Invalid event topic input", "Event topic input cannot be null or empty."),
+        ERROR_NULL_EVENT_PAYLOAD("60003", "Invalid event payload input ",
+                "Event payload input cannot be null."),
+        ERROR_INVALID_EVENT_URI("60004", "Invalid event URI input",
+                "Event URI input cannot be null or empty."),
+        ERROR_INVALID_EVENT_TOPIC("60005", "Invalid event topic input",
+                "Event topic input cannot be null or empty."),
         ERROR_INVALID_EVENT_ORGANIZATION_NAME("60006", "Invalid organization name input",
                 "Event organization name input cannot be null or empty."),
-        ERROR_INVALID_TOPIC("60007", "Invalid WebSub hub topic input", "WebSub hub topic cannot be null " +
-                "or empty."),
-        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSub hub base URL input", "WebSub hub base URL cannot " +
-                "be null or empty."),
-        ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input", "WebSub operation cannot be null " +
-                "or empty."),
+        ERROR_INVALID_TOPIC("60007", "Invalid WebSub hub topic input",
+                "WebSub hub topic cannot be null or empty."),
+        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSub hub base URL input",
+                "WebSub hub base URL cannot be null or empty."),
+        ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input",
+                "WebSub operation cannot be null or empty."),
         WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
                 "WebSub Hub adapter is disabled."),
+        ERROR_INVALID_CALLBACK_URL("60011", "Invalid callback URL input",
+                "Callback URL cannot be null or empty."),
+        ERROR_INVALID_SUBSCRIPTION_TOPICS("60012", "Invalid subscription topics",
+                "Subscription topics cannot be null or empty."),
 
         // server errors
         ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSub Hub topic.",
@@ -87,7 +107,8 @@ public class WebSubHubAdapterConstants {
         ERROR_DEREGISTERING_HUB_TOPIC("65002", "Error de-registering WebSub Hub topic.",
                 "Server error encountered while de-registering the WebSub Hub topic: %s, tenant: %s."),
         ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB("65003", "Backend error from WebSub Hub topic management.",
-                "Backend error received from WebSubHub topic management, topic: %s, operation: %s, payload: %s."),
+                "Backend error received from WebSubHub topic management, topic: %s, operation: %s, " +
+                        "payload: %s."),
         ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB("65004", "Error response from WebSub Hub.",
                 "Invalid response received from WebSub Hub, topic: %s, operation: %s, payload: %s."),
         ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB("65005", "Empty Response from WebSub Hub.",
@@ -98,8 +119,19 @@ public class WebSubHubAdapterConstants {
                 "Server error encountered while preparing SSL context for WebSubHub http client."),
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
                 "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
-        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic", "Backend error" +
-                " received from WebSubHub while attempting to de-register topic: %s. Active subscribers: %s.");
+        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic",
+                "Backend error" +
+                " received from WebSubHub while attempting to de-register topic: %s. Active subscribers: %s."),
+        ERROR_SUBSCRIBING_TO_TOPIC("65010", "Error subscribing to WebSub Hub topic.",
+                "Server error encountered while subscribing to the WebSub Hub topic: %s, tenant: %s, " +
+                        "callback: %s."),
+        ERROR_UNSUBSCRIBING_FROM_TOPIC("65011", "Error unsubscribing from WebSub Hub topic.",
+                "Server error encountered while unsubscribing from the WebSub Hub topic: %s, tenant: %s, " +
+                        "callback: %s."),
+        ERROR_SUBSCRIPTION_ALREADY_EXISTS("65012", "Subscription already exists.",
+                "Subscription already exists for topic: %s and callback: %s."),
+        ERROR_SUBSCRIPTION_NOT_FOUND("65013", "Subscription not found.",
+                "No subscription found for topic: %s and callback: %s.");
 
         private static final String WEB_SUB_ADAPTER_ERROR_CODE_PREFIX = "WEBSUB-";
         private final String code;
@@ -107,20 +139,24 @@ public class WebSubHubAdapterConstants {
         private final String description;
 
         ErrorMessages(String code, String message, String description) {
+
             this.code = code;
             this.message = message;
             this.description = description;
         }
 
         public String getCode() {
+
             return WEB_SUB_ADAPTER_ERROR_CODE_PREFIX + code;
         }
 
         public String getMessage() {
+
             return message;
         }
 
         public String getDescription() {
+
             return description;
         }
     }
@@ -130,7 +166,9 @@ public class WebSubHubAdapterConstants {
      */
     public static class LogConstants {
 
-        private LogConstants() {}
+        private LogConstants() {
+
+        }
 
         public static final String WEB_SUB_HUB_ADAPTER = "web-sub-hub-adapter";
 
@@ -139,9 +177,13 @@ public class WebSubHubAdapterConstants {
          */
         public static class ActionIDs {
 
-            private ActionIDs() {}
+            private ActionIDs() {
+
+            }
 
             public static final String PUBLISH_EVENT = "publish-event";
+            public static final String SUBSCRIBE = "subscribe";
+            public static final String UNSUBSCRIBE = "unsubscribe";
         }
 
         /**
@@ -149,7 +191,9 @@ public class WebSubHubAdapterConstants {
          */
         public static class InputKeys {
 
-            private InputKeys() {}
+            private InputKeys() {
+
+            }
 
             public static final String URL = "url";
             public static final String TENANT_DOMAIN = "tenant domain";
@@ -157,5 +201,7 @@ public class WebSubHubAdapterConstants {
         }
     }
 
-    private WebSubHubAdapterConstants() {}
+    private WebSubHubAdapterConstants() {
+
+    }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -38,7 +38,7 @@ public class WebSubHubAdapterConstants {
     }
 
     /**
-     * WebSub Hub Adapter related constants.
+     * WebSubHub Adapter related constants.
      */
     public static class Http {
 
@@ -76,8 +76,8 @@ public class WebSubHubAdapterConstants {
      */
     public enum ErrorMessages {
         // client errors
-        WEB_SUB_BASE_URL_NOT_CONFIGURED("60001", "WebSub Hub base URL is not configured.",
-                "WebSub Hub base URL is not configured."),
+        WEB_SUB_BASE_URL_NOT_CONFIGURED("60001", "WebSubHub base URL is not configured.",
+                "WebSubHub base URL is not configured."),
         ERROR_PUBLISHING_EVENT_INVALID_PAYLOAD("60002", "Invalid payload provided.",
                 "Event payload cannot be processed."),
         ERROR_NULL_EVENT_PAYLOAD("60003", "Invalid event payload input ",
@@ -88,14 +88,14 @@ public class WebSubHubAdapterConstants {
                 "Event topic input cannot be null or empty."),
         ERROR_INVALID_EVENT_ORGANIZATION_NAME("60006", "Invalid organization name input",
                 "Event organization name input cannot be null or empty."),
-        ERROR_INVALID_TOPIC("60007", "Invalid WebSubhub topic input",
-                "WebSubhub topic cannot be null or empty."),
-        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSubhub base URL input",
-                "WebSubhub base URL cannot be null or empty."),
-        ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input",
-                "WebSub operation cannot be null or empty."),
-        WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
-                "WebSub Hub adapter is disabled."),
+        ERROR_INVALID_TOPIC("60007", "Invalid WebSubHub topic input",
+                "WebSubHub topic cannot be null or empty."),
+        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSubHub base URL input",
+                "WebSubHub base URL cannot be null or empty."),
+        ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSubHub operation input",
+                "WebSubHub operation cannot be null or empty."),
+        WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSubHub adapter is disabled.",
+                "WebSubHub adapter is disabled."),
         ERROR_INVALID_CALLBACK_URL("60011", "Invalid callback URL input",
                 "Callback URL cannot be null or empty."),
         ERROR_INVALID_SUBSCRIPTION_TOPICS("60012", "Invalid subscription topics",
@@ -119,7 +119,7 @@ public class WebSubHubAdapterConstants {
                 "Server error encountered while preparing SSL context for WebSubHub http client."),
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
                 "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
-        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic",
+        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic ",
                 "WebSubHub returned" +
                 " an error while attempting to de-register topic: %s. Active subscribers: %s."),
         ERROR_SUBSCRIBING_TO_TOPIC("65010", "Error subscribing to WebSub Hub topic.",

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -102,31 +102,31 @@ public class WebSubHubAdapterConstants {
                 "Subscription topics cannot be null or empty."),
 
         // server errors
-        ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSub Hub topic.",
-                "Server error encountered while registering the WebSub Hub topic: %s, tenant: %s."),
-        ERROR_DEREGISTERING_HUB_TOPIC("65002", "Error de-registering WebSub Hub topic.",
-                "Server error encountered while de-registering the WebSub Hub topic: %s, tenant: %s."),
-        ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB("65003", "Backend error from WebSub Hub topic management.",
+        ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSubHub topic.",
+                "Server error encountered while registering the WebSubHub topic: %s, tenant: %s."),
+        ERROR_DEREGISTERING_HUB_TOPIC("65002", "Error de-registering WebSubHub topic.",
+                "Server error encountered while de-registering the WebSubHub topic: %s, tenant: %s."),
+        ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB("65003", "Backend error from WebSubHub topic management.",
                 "Backend error received from WebSubHub topic management, topic: %s, operation: %s, " +
                         "payload: %s."),
-        ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB("65004", "Error response from WebSub Hub.",
-                "Invalid response received from WebSub Hub, topic: %s, operation: %s, payload: %s."),
-        ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB("65005", "Empty Response from WebSub Hub.",
-                "Received empty response from WebSub Hub, topic: %s, operation: %s."),
+        ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB("65004", "Error response from WebSubHub.",
+                "Invalid response received from WebSubHub, topic: %s, operation: %s, payload: %s."),
+        ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB("65005", "Empty Response from WebSubHub.",
+                "Received empty response from WebSubHub, topic: %s, operation: %s."),
         ERROR_GETTING_ASYNC_CLIENT("65006", "Error getting the async client to publish events.",
                 "Error preparing async client to publish events, tenant: %s."),
         ERROR_CREATING_SSL_CONTEXT("65007", "Error while preparing SSL context for WebSubHub http client.",
                 "Server error encountered while preparing SSL context for WebSubHub http client."),
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
-                "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
+                "Server error encountered while creating the Async HTTP Client of WebSubHub Adapter."),
         TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic ",
                 "WebSubHub returned" +
                 " an error while attempting to de-register topic: %s. Active subscribers: %s."),
-        ERROR_SUBSCRIBING_TO_TOPIC("65010", "Error subscribing to WebSub Hub topic.",
-                "Server error encountered while subscribing to the WebSub Hub topic: %s, tenant: %s, " +
+        ERROR_SUBSCRIBING_TO_TOPIC("65010", "Error subscribing to WebSubHub topic.",
+                "Server error encountered while subscribing to the WebSubHub topic: %s, tenant: %s, " +
                         "callback: %s."),
-        ERROR_UNSUBSCRIBING_FROM_TOPIC("65011", "Error unsubscribing from WebSub Hub topic.",
-                "Server error encountered while unsubscribing from the WebSub Hub topic: %s, tenant: %s, " +
+        ERROR_UNSUBSCRIBING_FROM_TOPIC("65011", "Error unsubscribing from WebSubHub topic.",
+                "Server error encountered while unsubscribing from the WebSubHub topic: %s, tenant: %s, " +
                         "callback: %s."),
         ERROR_SUBSCRIPTION_ALREADY_EXISTS("65012", "Subscription already exists.",
                 "Subscription already exists for topic: %s and callback: %s."),

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -88,10 +88,10 @@ public class WebSubHubAdapterConstants {
                 "Event topic input cannot be null or empty."),
         ERROR_INVALID_EVENT_ORGANIZATION_NAME("60006", "Invalid organization name input",
                 "Event organization name input cannot be null or empty."),
-        ERROR_INVALID_TOPIC("60007", "Invalid WebSub hub topic input",
-                "WebSub hub topic cannot be null or empty."),
-        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSub hub base URL input",
-                "WebSub hub base URL cannot be null or empty."),
+        ERROR_INVALID_TOPIC("60007", "Invalid WebSubhub topic input",
+                "WebSubhub topic cannot be null or empty."),
+        ERROR_INVALID_WEB_SUB_HUB_BASE_URL("60008", "Invalid WebSubhub base URL input",
+                "WebSubhub base URL cannot be null or empty."),
         ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input",
                 "WebSub operation cannot be null or empty."),
         WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
@@ -120,8 +120,8 @@ public class WebSubHubAdapterConstants {
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
                 "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
         TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic",
-                "Backend error" +
-                " received from WebSubHub while attempting to de-register topic: %s. Active subscribers: %s."),
+                "WebSubHub returned" +
+                " an error while attempting to de-register topic: %s. Active subscribers: %s."),
         ERROR_SUBSCRIBING_TO_TOPIC("65010", "Error subscribing to WebSub Hub topic.",
                 "Server error encountered while subscribing to the WebSub Hub topic: %s, tenant: %s, " +
                         "callback: %s."),

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterClientException.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterClientException.java
@@ -19,7 +19,7 @@
 package org.wso2.identity.event.websubhub.publisher.exception;
 
 /**
- * Exception wrapper class for WebSub Adapter exceptions.
+ * Exception wrapper class for WebSubHub Adapter exceptions.
  */
 public class WebSubAdapterClientException extends WebSubAdapterException {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterException.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterException.java
@@ -19,7 +19,7 @@
 package org.wso2.identity.event.websubhub.publisher.exception;
 
 /**
- * Exception wrapper class for WebSub Adapter exceptions.
+ * Exception wrapper class for WebSubHub Adapter exceptions.
  */
 public class WebSubAdapterException extends Exception {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterServerException.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/exception/WebSubAdapterServerException.java
@@ -19,7 +19,7 @@
 package org.wso2.identity.event.websubhub.publisher.exception;
 
 /**
- * Exception wrapper class for WebSub Adapter exceptions.
+ * Exception wrapper class for WebSubHub Adapter exceptions.
  */
 public class WebSubAdapterServerException extends WebSubAdapterException {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -79,7 +79,12 @@ public class ClientManager {
                     .setSSLContext(createSSLContext());
             httpAsyncClient = httpAsyncClientBuilder.build();
             httpAsyncClient.start();
-            LOG.debug("HttpAsyncClient started");
+            LOG.debug("HttpAsyncClient started with config: connectTimeout=" +
+                    config.getConnectTimeout() + ", connectionRequestTimeout=" +
+                    config.getConnectionRequestTimeout() + ", socketTimeout=" +
+                    config.getSocketTimeout() + ", maxConnections=" +
+                    asyncConnectionManager.getMaxTotal() + ", maxConnectionsPerRoute=" +
+                    asyncConnectionManager.getDefaultMaxPerRoute());
 
             // Initialize CloseableHttpClient
             PoolingHttpClientConnectionManager syncConnectionManager =
@@ -89,7 +94,12 @@ public class ClientManager {
                     .setConnectionManager(syncConnectionManager)
                     .setSSLContext(createSSLContext())
                     .build();
-            LOG.debug("CloseableHttpClient initialized with SSL and connection configurations");
+            LOG.debug("CloseableHttpClient initialized with config: connectTimeout=" +
+                    config.getConnectTimeout() + ", connectionRequestTimeout=" +
+                    config.getConnectionRequestTimeout() + ", socketTimeout=" +
+                    config.getSocketTimeout() + ", maxConnections=" +
+                    syncConnectionManager.getMaxTotal() + ", maxConnectionsPerRoute=" +
+                    syncConnectionManager.getDefaultMaxPerRoute());
         } catch (IOException e) {
             throw WebSubHubAdapterUtil.handleServerException(
                     WebSubHubAdapterConstants.ErrorMessages.ERROR_GETTING_ASYNC_CLIENT, e);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -60,18 +60,18 @@ public class WebSubHubAdapterServiceComponent {
                         subscriberService, null);
                 WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
                 WebSubHubAdapterDataHolder.getInstance().setResourceRetriever(new DefaultResourceRetriever());
-                log.debug("Successfully activated the WebSub Hub adapter service.");
+                log.debug("Successfully activated the WebSubHub adapter service.");
             } else {
-                log.error("WebSub Hub Adapter is not enabled.");
+                log.error("WebSubHub Adapter is not enabled.");
             }
         } catch (Throwable e) {
-            log.error("Can not activate the WebSub Hub adapter service: " + e.getMessage(), e);
+            log.error("Can not activate the WebSubHub adapter service: " + e.getMessage(), e);
         }
     }
 
     @Deactivate
     protected void deactivate(ComponentContext context) {
 
-        log.debug("Successfully de-activated the WebSub Hub adapter service.");
+        log.debug("Successfully de-activated the WebSubHub adapter service.");
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.wso2.carbon.identity.webhook.management.api.service.WebhookSubscriber;
+import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.common.publisher.EventPublisher;
 import org.wso2.identity.event.websubhub.publisher.config.OutboundAdapterConfigurationProvider;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
@@ -56,7 +56,7 @@ public class WebSubHubAdapterServiceComponent {
 
                 // Register WebhookSubscriber service
                 WebSubEventSubscriberImpl subscriberService = new WebSubEventSubscriberImpl();
-                context.getBundleContext().registerService(WebhookSubscriber.class.getName(),
+                context.getBundleContext().registerService(EventSubscriber.class.getName(),
                         subscriberService, null);
                 WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
                 WebSubHubAdapterDataHolder.getInstance().setResourceRetriever(new DefaultResourceRetriever());

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -75,5 +75,3 @@ public class WebSubHubAdapterServiceComponent {
         log.debug("Successfully de-activated the WebSub Hub adapter service.");
     }
 }
-
-

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -25,10 +25,12 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.wso2.carbon.identity.webhook.management.api.service.WebhookSubscriber;
 import org.wso2.identity.event.common.publisher.EventPublisher;
 import org.wso2.identity.event.websubhub.publisher.config.OutboundAdapterConfigurationProvider;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
-import org.wso2.identity.event.websubhub.publisher.service.WebSubHubAdapterServiceImpl;
+import org.wso2.identity.event.websubhub.publisher.service.WebSubEventPublisherImpl;
+import org.wso2.identity.event.websubhub.publisher.service.WebSubEventSubscriberImpl;
 
 /**
  * WebSubHub Outbound Event Adapter service component.
@@ -47,8 +49,15 @@ public class WebSubHubAdapterServiceComponent {
             WebSubHubAdapterDataHolder.getInstance().setAdapterConfiguration(new WebSubAdapterConfiguration(
                     OutboundAdapterConfigurationProvider.getInstance()));
             if (WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration().isAdapterEnabled()) {
+                // Register EventPublisher service
+                WebSubEventPublisherImpl eventPublisherService = new WebSubEventPublisherImpl();
                 context.getBundleContext().registerService(EventPublisher.class.getName(),
-                        new WebSubHubAdapterServiceImpl(), null);
+                        eventPublisherService, null);
+
+                // Register WebhookSubscriber service
+                WebSubEventSubscriberImpl subscriberService = new WebSubEventSubscriberImpl();
+                context.getBundleContext().registerService(WebhookSubscriber.class.getName(),
+                        subscriberService, null);
                 WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
                 WebSubHubAdapterDataHolder.getInstance().setResourceRetriever(new DefaultResourceRetriever());
                 log.debug("Successfully activated the WebSub Hub adapter service.");

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -142,18 +142,11 @@ public class WebSubEventPublisherImpl implements EventPublisher {
         WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
         final long requestStartTime = System.currentTimeMillis();
 
-        CompletableFuture<HttpResponse> future = clientManager.executeAsync(httpPost);
-
-        future.thenAccept(response -> {
-            try {
-                handleTopicMgtResponse((CloseableHttpResponse) response, httpPost, topic, operation, requestStartTime);
-            } catch (IOException | WebSubAdapterException e) {
-                log.error("Handling topic management response failed. ", e);
-            }
-        }).exceptionally(ex -> {
-            log.error("Topic management API call failed. ", ex);
-            return null;
-        });
+        try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.execute(httpPost)) {
+            handleTopicMgtResponse(response, httpPost, topic, operation, requestStartTime);
+        } catch (IOException | WebSubAdapterException e) {
+            log.error("Topic management API call failed. ", e);
+        }
     }
 
     private void handleTopicMgtResponse(CloseableHttpResponse response, HttpPost httpPost,

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -77,11 +77,11 @@ public class WebSubEventPublisherImpl implements EventPublisher {
 
         makeAsyncAPICall(eventPayload, eventContext,
                 constructHubTopic(eventContext.getEventUri(), eventContext.getTenantDomain()), getWebSubBaseURL());
-        log.debug("Event published successfully to the WebSub Hub.");
+        log.debug("Event published successfully to the WebSubHub.");
     }
 
     /**
-     * Register a topic in the WebSub Hub.
+     * Register a topic in the WebSubHub.
      *
      * @param eventUri     Event URI.
      * @param tenantDomain Tenant domain.
@@ -91,12 +91,12 @@ public class WebSubEventPublisherImpl implements EventPublisher {
 
         makeTopicMgtAPICall(constructHubTopic(eventUri, tenantDomain), getWebSubBaseURL(),
                 WebSubHubAdapterConstants.Http.REGISTER, tenantDomain);
-        log.debug("WebSub Hub Topic registered successfully for the event: " + eventUri + " in tenant: " +
+        log.debug("WebSubHub Topic registered successfully for the event: " + eventUri + " in tenant: " +
                 tenantDomain);
     }
 
     /**
-     * Deregister a topic in the WebSub Hub.
+     * Deregister a topic in the WebSubHub.
      *
      * @param eventUri     Event URI.
      * @param tenantDomain Tenant domain.

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -18,7 +18,6 @@
 
 package org.wso2.identity.event.websubhub.publisher.service;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
@@ -27,7 +26,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -36,47 +34,40 @@ import org.wso2.identity.event.common.publisher.model.EventContext;
 import org.wso2.identity.event.common.publisher.model.SecurityEventTokenPayload;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
-import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterServerException;
 import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
 import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_WEB_SUB_HUB_BASE_URL;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.DEREGISTER;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_ACTIVE_SUBS;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_MODE;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_REASON;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_TOPIC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.PUBLISH;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.REGISTER;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.RESPONSE_FOR_SUCCESSFUL_OPERATION;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleClientException;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleErrorResponse;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleFailedOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleResponseCorrelationLog;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleServerException;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logDiagnosticFailure;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logDiagnosticSuccess;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logPublishingEvent;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.parseEventHubResponse;
 
-
 /**
  * OSGi service for publishing events using web sub hub.
  */
-public class WebSubHubAdapterServiceImpl implements EventPublisher {
+public class WebSubEventPublisherImpl implements EventPublisher {
 
-    private static final Log log = LogFactory.getLog(WebSubHubAdapterServiceImpl.class);
-    private String webSubHubBaseUrl = null;
+    private static final Log log = LogFactory.getLog(WebSubEventPublisherImpl.class);
 
     @Override
     public void publish(SecurityEventTokenPayload eventPayload, EventContext eventContext)
@@ -115,29 +106,8 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
                 getWebSubBaseURL(), DEREGISTER);
     }
 
-    private String getWebSubBaseURL() throws WebSubAdapterException {
-
-        if (StringUtils.isEmpty(webSubHubBaseUrl)) {
-            webSubHubBaseUrl =
-                    WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration().getWebSubHubBaseUrl();
-
-            // At this point, url shouldn't be null since if adapter is enabled, url is mandatory to configured.
-            // But adding this as a second level verification.
-            if (StringUtils.isEmpty(webSubHubBaseUrl)) {
-                throw handleClientException
-                        (WebSubHubAdapterConstants.ErrorMessages.WEB_SUB_BASE_URL_NOT_CONFIGURED);
-            }
-        }
-        return webSubHubBaseUrl;
-    }
-
-    private String constructHubTopic(String topicSuffix, String tenantDomain) {
-
-        return tenantDomain + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + topicSuffix;
-    }
-
     private void makeAsyncAPICall(SecurityEventTokenPayload eventPayload, EventContext eventContext,
-                                        String topic, String webSubHubBaseUrl) throws WebSubAdapterException {
+                                  String topic, String webSubHubBaseUrl) throws WebSubAdapterException {
 
         String url = buildURL(topic, webSubHubBaseUrl, PUBLISH);
 
@@ -159,20 +129,6 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
                     log.error("Publishing event data to WebSubHub failed. ", ex);
                     throw new IdentityRuntimeException("Error occurred while publishing event data to WebSubHub. ", ex);
                 });
-    }
-
-    private static String buildURL(String topic, String webSubHubBaseUrl, String operation)
-            throws WebSubAdapterServerException {
-
-        try {
-            URIBuilder uriBuilder = new URIBuilder(webSubHubBaseUrl);
-            uriBuilder.addParameter(HUB_MODE, operation);
-            uriBuilder.addParameter(HUB_TOPIC, topic);
-            return uriBuilder.build().toString();
-        } catch (URISyntaxException e) {
-            log.error("Error building URL", e);
-            throw handleServerException(ERROR_INVALID_WEB_SUB_HUB_BASE_URL, e);
-        }
     }
 
     private void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation)
@@ -201,7 +157,7 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
     }
 
     private void handleTopicMgtResponse(CloseableHttpResponse response, HttpPost httpPost,
-                                               String topic, String operation, long requestStartTime)
+                                        String topic, String operation, long requestStartTime)
             throws IOException, WebSubAdapterException {
 
         StatusLine statusLine = response.getStatusLine();
@@ -213,14 +169,14 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
                     WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
                     String.valueOf(responseCode), responsePhrase);
-            handleSuccessfulTopicMgt(entity, topic, operation);
+            handleSuccessfulOperation(entity, topic, operation);
         } else if ((responseCode == HttpStatus.SC_CONFLICT && operation.equals(REGISTER)) ||
                 (responseCode == HttpStatus.SC_NOT_FOUND && operation.equals(DEREGISTER))) {
             HttpEntity entity = response.getEntity();
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
                     WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
                     String.valueOf(responseCode), responsePhrase);
-            handleConflictOrNotFound(entity, topic, operation);
+            handleErrorResponse(entity, topic, operation);
         } else {
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
                     WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
@@ -229,12 +185,12 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
                 handleForbiddenResponse(response, topic);
             }
             HttpEntity entity = response.getEntity();
-            handleFailedTopicMgt(entity, topic, operation, responseCode);
+            handleFailedOperation(entity, topic, operation, responseCode);
         }
     }
 
     private static void handleAsyncResponse(HttpResponse response, HttpPost request, long requestStartTime,
-                                             EventContext eventContext, String url, String topic) {
+                                            EventContext eventContext, String url, String topic) {
 
         PrivilegedCarbonContext.startTenantFlow();
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(eventContext.getTenantDomain());
@@ -269,7 +225,7 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
                                 errorResponseBody);
                     } else {
                         log.error("WebHubSub event publisher received " + responseCode +
-                                  " code. Response entity is null.");
+                                " code. Response entity is null.");
                     }
                 } catch (IOException e) {
                     log.error("Error while reading WebSubHub event publisher response. ", e);
@@ -278,46 +234,6 @@ public class WebSubHubAdapterServiceImpl implements EventPublisher {
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
-    }
-
-    private static void handleSuccessfulTopicMgt(HttpEntity entity, String topic, String operation)
-            throws WebSubAdapterException, IOException {
-
-        if (entity != null) {
-            String responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-            if (RESPONSE_FOR_SUCCESSFUL_OPERATION.equals(responseString)) {
-                log.debug("Success WebSub Hub operation: " + operation + ", topic: " + topic);
-            } else {
-                throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null,
-                        topic, operation, responseString);
-            }
-        } else {
-            String message = String.format(ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getDescription(), topic, operation);
-            throw new WebSubAdapterServerException(message, ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getCode());
-        }
-    }
-
-    private static void handleConflictOrNotFound(HttpEntity entity, String topic, String operation) throws IOException {
-
-        String responseString = "";
-        if (entity != null) {
-            responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-        }
-        log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
-                topic, operation, responseString));
-    }
-
-    private static void handleFailedTopicMgt(HttpEntity entity, String topic, String operation, int responseCode)
-            throws IOException, WebSubAdapterException {
-
-        String responseString = "";
-        if (entity != null) {
-            responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
-        }
-        String message = String.format(ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getDescription(),
-                topic, operation, responseString);
-        log.error(message + ", Response code:" + responseCode);
-        throw new WebSubAdapterServerException(message, ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getCode());
     }
 
     private static void handleForbiddenResponse(CloseableHttpResponse response, String topic) throws IOException,

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.websubhub.publisher.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
+import org.wso2.carbon.identity.webhook.management.api.service.WebhookSubscriber;
+import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
+import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
+import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildSubscriptionURL;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleErrorResponse;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleFailedOperation;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
+
+/**
+ * OSGi service for managing WebSub Hub subscriptions.
+ */
+public class WebSubEventSubscriberImpl implements WebhookSubscriber {
+
+    private static final Log log = LogFactory.getLog(WebSubEventSubscriberImpl.class);
+
+    @Override
+    public String getName() {
+
+        return WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME;
+    }
+
+    @Override
+    public boolean subscribe(List<String> topics, String callbackUrl, String tenantDomain) throws WebhookMgtException {
+
+        try {
+            for (String topic : topics) {
+                makeSubscriptionAPICall(constructHubTopic(topic, tenantDomain), getWebSubBaseURL(),
+                        WebSubHubAdapterConstants.Http.SUBSCRIBE, callbackUrl);
+                log.debug("WebSub Hub subscription successful for topic: " + topic + " with callback URL: " +
+                        callbackUrl + " in tenant: " + tenantDomain);
+            }
+            return true;
+        } catch (WebSubAdapterException e) {
+            log.error("Error subscribing to topics in WebSub Hub.", e);
+            throw new WebhookMgtException("Failed to subscribe to topics in WebSub Hub", e);
+        }
+    }
+
+    @Override
+    public boolean unsubscribe(List<String> topics, String callbackUrl, String tenantDomain)
+            throws WebhookMgtException {
+
+        try {
+            for (String topic : topics) {
+                makeSubscriptionAPICall(constructHubTopic(topic, tenantDomain), getWebSubBaseURL(),
+                        WebSubHubAdapterConstants.Http.UNSUBSCRIBE, callbackUrl);
+                log.debug("WebSub Hub unsubscription successful for topic: " + topic + " with callback URL: " +
+                        callbackUrl + " in tenant: " + tenantDomain);
+            }
+            return true;
+        } catch (WebSubAdapterException e) {
+            log.error("Error unsubscribing from topics in WebSub Hub.", e);
+            throw new WebhookMgtException("Failed to unsubscribe from topics in WebSub Hub", e);
+        }
+    }
+
+    private void makeSubscriptionAPICall(String topic, String webSubHubBaseUrl, String operation, String callbackUrl)
+            throws WebSubAdapterException {
+
+        String subscriptionUrl = buildSubscriptionURL(topic, webSubHubBaseUrl, operation, callbackUrl);
+
+        ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
+        HttpPost httpPost = clientManager.createHttpPost(subscriptionUrl, null);
+
+        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
+        final long requestStartTime = System.currentTimeMillis();
+
+        CompletableFuture<HttpResponse> future = clientManager.executeAsync(httpPost);
+
+        future.thenAccept(response -> {
+            try {
+                handleSubscriptionResponse((CloseableHttpResponse) response, httpPost, topic, operation,
+                        requestStartTime);
+            } catch (IOException | WebSubAdapterException e) {
+                log.error("Handling subscription response failed. ", e);
+            }
+        }).exceptionally(ex -> {
+            log.error("Subscription API call failed. ", ex);
+            return null;
+        });
+    }
+
+    private void handleSubscriptionResponse(CloseableHttpResponse response, HttpPost httpPost,
+                                            String topic, String operation, long requestStartTime)
+            throws IOException, WebSubAdapterException {
+
+        StatusLine statusLine = response.getStatusLine();
+        int responseCode = statusLine.getStatusCode();
+        String responsePhrase = statusLine.getReasonPhrase();
+
+        if (responseCode == HttpStatus.SC_OK) {
+            HttpEntity entity = response.getEntity();
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            handleSuccessfulOperation(entity, topic, operation);
+        } else if (responseCode == HttpStatus.SC_NOT_FOUND) {
+            HttpEntity entity = response.getEntity();
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            handleErrorResponse(entity, topic, operation);
+        } else {
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            HttpEntity entity = response.getEntity();
+            handleFailedOperation(entity, topic, operation, responseCode);
+        }
+    }
+}

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -59,20 +59,22 @@ public class WebSubEventSubscriberImpl implements WebhookSubscriber {
     }
 
     @Override
-    public boolean subscribe(List<String> topics, String callbackUrl, String tenantDomain) throws WebhookMgtException {
+    public CompletableFuture<Boolean> subscribe(List<String> topics, String callbackUrl, String tenantDomain) {
 
-        try {
-            for (String topic : topics) {
-                makeSubscriptionAPICall(constructHubTopic(topic, tenantDomain), getWebSubBaseURL(),
-                        WebSubHubAdapterConstants.Http.SUBSCRIBE, callbackUrl);
-                log.debug("WebSub Hub subscription successful for topic: " + topic + " with callback URL: " +
-                        callbackUrl + " in tenant: " + tenantDomain);
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                for (String topic : topics) {
+                    makeSubscriptionAPICall(constructHubTopic(topic, tenantDomain), getWebSubBaseURL(),
+                            WebSubHubAdapterConstants.Http.SUBSCRIBE, callbackUrl);
+                    log.debug("WebSub Hub subscription successful for topic: " + topic + " with callback URL: " +
+                            callbackUrl + " in tenant: " + tenantDomain);
+                }
+                return true;
+            } catch (WebSubAdapterException e) {
+                log.error("Error subscribing to topics in WebSub Hub.", e);
+                throw new RuntimeException("Failed to subscribe to topics in WebSub Hub", e);
             }
-            return true;
-        } catch (WebSubAdapterException e) {
-            log.error("Error subscribing to topics in WebSub Hub.", e);
-            throw new WebhookMgtException("Failed to subscribe to topics in WebSub Hub", e);
-        }
+        });
     }
 
     @Override

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -45,8 +45,9 @@ import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterU
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
 
 /**
- * OSGi service for managing WebSub Hub subscriptions.
+ * OSGi service for managing WebSubHub subscriptions.
  * TODO: Introduce a proper exception handler for the subscriber with explicit error codes.
+ * TODO: Add diagnostic logs
  */
 public class WebSubEventSubscriberImpl implements EventSubscriber {
 
@@ -68,7 +69,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
                             getWebSubBaseURL(),
                             WebSubHubAdapterConstants.Http.SUBSCRIBE,
                             callbackUrl);
-                    log.debug("WebSub Hub subscription successful for topic: " + topic +
+                    log.debug("WebSubHub subscription successful for topic: " + topic +
                             " with callback URL: " + callbackUrl + " in tenant: " + tenantDomain);
                 } catch (WebSubAdapterException e) {
                     log.error("Error subscribing to topic: " + topic, e);
@@ -92,7 +93,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
                             getWebSubBaseURL(),
                             WebSubHubAdapterConstants.Http.UNSUBSCRIBE,
                             callbackUrl);
-                    log.debug("WebSub Hub unsubscription successful for topic: " + topic +
+                    log.debug("WebSubHub unsubscription successful for topic: " + topic +
                             " with callback URL: " + callbackUrl + " in tenant: " + tenantDomain);
                 } catch (WebSubAdapterException e) {
                     log.error("Error unsubscribing to topic: " + topic, e);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -25,7 +25,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.wso2.carbon.identity.webhook.management.api.service.WebhookSubscriber;
+import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
 import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
@@ -48,7 +48,7 @@ import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterU
  * OSGi service for managing WebSub Hub subscriptions.
  * TODO: Introduce a proper exception handler for the subscriber with explicit error codes.
  */
-public class WebSubEventSubscriberImpl implements WebhookSubscriber {
+public class WebSubEventSubscriberImpl implements EventSubscriber {
 
     private static final Log log = LogFactory.getLog(WebSubEventSubscriberImpl.class);
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.MDC;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
@@ -32,16 +33,27 @@ import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.identity.event.common.publisher.model.EventContext;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterClientException;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterServerException;
+import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_WEB_SUB_HUB_BASE_URL;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.CORRELATION_ID_REQUEST_HEADER;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_CALLBACK;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_MODE;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_TOPIC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.RESPONSE_FOR_SUCCESSFUL_OPERATION;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.URL_KEY_VALUE_SEPARATOR;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.URL_PARAM_SEPARATOR;
 
@@ -52,7 +64,9 @@ public class WebSubHubAdapterUtil {
 
     private static final Log log = LogFactory.getLog(WebSubHubAdapterUtil.class);
 
-    private WebSubHubAdapterUtil() {}
+    private WebSubHubAdapterUtil() {
+
+    }
 
     /**
      * Get the correlation ID.
@@ -107,9 +121,9 @@ public class WebSubHubAdapterUtil {
     /**
      * Parse the response from the event hub.
      *
-     * @param response
-     * @return
-     * @throws IOException
+     * @param response HTTP response.
+     * @return Parsed response as a map.
+     * @throws IOException If an error occurs while reading the response.
      */
     public static Map<String, String> parseEventHubResponse(CloseableHttpResponse response) throws IOException {
 
@@ -133,9 +147,9 @@ public class WebSubHubAdapterUtil {
     /**
      * Handle the response correlation log.
      *
-     * @param request           HTTP POST request.
-     * @param requestStartTime  Request start time.
-     * @param otherParams       Other parameters.
+     * @param request          HTTP POST request.
+     * @param requestStartTime Request start time.
+     * @param otherParams      Other parameters.
      */
     public static void handleResponseCorrelationLog(HttpPost request, long requestStartTime, String... otherParams) {
 
@@ -222,5 +236,150 @@ public class WebSubHubAdapterUtil {
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }
+    }
+
+    /**
+     * Build URL for WebSub Hub operations.
+     *
+     * @param topic            Topic.
+     * @param webSubHubBaseUrl WebSub Hub base URL.
+     * @param operation        Operation.
+     * @return URL.
+     * @throws WebSubAdapterServerException If an error occurs while building the URL.
+     */
+    public static String buildURL(String topic, String webSubHubBaseUrl, String operation)
+            throws WebSubAdapterServerException {
+
+        try {
+            URIBuilder uriBuilder = new URIBuilder(webSubHubBaseUrl);
+            uriBuilder.addParameter(HUB_MODE, operation);
+            uriBuilder.addParameter(HUB_TOPIC, topic);
+            return uriBuilder.build().toString();
+        } catch (URISyntaxException e) {
+            log.error("Error building URL", e);
+            throw handleServerException(ERROR_INVALID_WEB_SUB_HUB_BASE_URL, e);
+        }
+    }
+
+    /**
+     * Build URL for WebSub Hub subscription operations.
+     *
+     * @param topic            Topic.
+     * @param webSubHubBaseUrl WebSub Hub base URL.
+     * @param operation        Operation.
+     * @param callbackUrl      Callback URL.
+     * @return URL.
+     * @throws WebSubAdapterServerException If an error occurs while building the URL.
+     */
+    public static String buildSubscriptionURL(String topic, String webSubHubBaseUrl, String operation,
+                                              String callbackUrl)
+            throws WebSubAdapterServerException {
+
+        try {
+            URIBuilder uriBuilder = new URIBuilder(webSubHubBaseUrl);
+            uriBuilder.addParameter(HUB_MODE, operation);
+            uriBuilder.addParameter(HUB_TOPIC, topic);
+            uriBuilder.addParameter(HUB_CALLBACK, callbackUrl);
+            return uriBuilder.build().toString();
+        } catch (URISyntaxException e) {
+            log.error("Error building subscription URL", e);
+            throw handleServerException(ERROR_INVALID_WEB_SUB_HUB_BASE_URL, e);
+        }
+    }
+
+    /**
+     * Construct the hub topic by combining tenant domain and topic suffix.
+     *
+     * @param topicSuffix  Topic suffix.
+     * @param tenantDomain Tenant domain.
+     * @return Hub topic.
+     */
+    public static String constructHubTopic(String topicSuffix, String tenantDomain) {
+
+        return tenantDomain + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + topicSuffix;
+    }
+
+    /**
+     * Get the WebSub Hub base URL from configuration.
+     *
+     * @return WebSub Hub base URL.
+     * @throws WebSubAdapterException If the WebSub Hub base URL is not configured.
+     */
+    public static String getWebSubBaseURL() throws WebSubAdapterException {
+
+        String webSubHubBaseUrl =
+                WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration().getWebSubHubBaseUrl();
+
+        if (StringUtils.isEmpty(webSubHubBaseUrl)) {
+            throw handleClientException(WebSubHubAdapterConstants.ErrorMessages.WEB_SUB_BASE_URL_NOT_CONFIGURED);
+        }
+        return webSubHubBaseUrl;
+    }
+
+    /**
+     * Handle successful WebSub Hub operations.
+     *
+     * @param entity    HTTP entity.
+     * @param topic     Topic.
+     * @param operation Operation.
+     * @throws WebSubAdapterException If an error occurs while handling the response.
+     * @throws IOException            If an error occurs while reading the response.
+     */
+    public static void handleSuccessfulOperation(HttpEntity entity, String topic, String operation)
+            throws WebSubAdapterException, IOException {
+
+        if (entity != null) {
+            String responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+            if (RESPONSE_FOR_SUCCESSFUL_OPERATION.equals(responseString)) {
+                log.debug("Success WebSub Hub operation: " + operation + ", topic: " + topic);
+            } else {
+                throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null,
+                        topic, operation, responseString);
+            }
+        } else {
+            String message = String.format(ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getDescription(), topic, operation);
+            throw new WebSubAdapterServerException(message, ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getCode());
+        }
+    }
+
+    /**
+     * Handle error responses (e.g., conflict or not found) from WebSub Hub.
+     *
+     * @param entity    HTTP entity.
+     * @param topic     Topic.
+     * @param operation Operation.
+     * @throws IOException If an error occurs while reading the response.
+     */
+    public static void handleErrorResponse(HttpEntity entity, String topic, String operation) throws IOException {
+
+        String responseString = "";
+        if (entity != null) {
+            responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+        }
+        log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
+                topic, operation, responseString));
+    }
+
+    /**
+     * Handle failed WebSub Hub operations.
+     *
+     * @param entity       HTTP entity.
+     * @param topic        Topic.
+     * @param operation    Operation.
+     * @param responseCode Response code.
+     * @throws IOException            If an error occurs while reading the response.
+     * @throws WebSubAdapterException If an error occurs while handling the response.
+     */
+    public static void handleFailedOperation(HttpEntity entity, String topic, String operation, int responseCode)
+            throws IOException, WebSubAdapterException {
+
+        String responseString = "";
+        if (entity != null) {
+            responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+        }
+        String message = String.format(ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getDescription(),
+                topic, operation, responseString);
+        log.error(message + ", Response code:" + responseCode);
+        throw new WebSubAdapterServerException(message, ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getCode());
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -239,10 +239,10 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Build URL for WebSub Hub operations.
+     * Build URL for WebSubHub operations.
      *
      * @param topic            Topic.
-     * @param webSubHubBaseUrl WebSub Hub base URL.
+     * @param webSubHubBaseUrl WebSubHub base URL.
      * @param operation        Operation.
      * @return URL.
      * @throws WebSubAdapterServerException If an error occurs while building the URL.
@@ -262,10 +262,10 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Build URL for WebSub Hub subscription operations.
+     * Build URL for WebSubHub subscription operations.
      *
      * @param topic            Topic.
-     * @param webSubHubBaseUrl WebSub Hub base URL.
+     * @param webSubHubBaseUrl WebSubHub base URL.
      * @param operation        Operation.
      * @param callbackUrl      Callback URL.
      * @return URL.
@@ -300,10 +300,10 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Get the WebSub Hub base URL from configuration.
+     * Get the WebSubHub base URL from configuration.
      *
-     * @return WebSub Hub base URL.
-     * @throws WebSubAdapterException If the WebSub Hub base URL is not configured.
+     * @return WebSubHub base URL.
+     * @throws WebSubAdapterException If the WebSubHub base URL is not configured.
      */
     public static String getWebSubBaseURL() throws WebSubAdapterException {
 
@@ -317,7 +317,7 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Handle successful WebSub Hub operations.
+     * Handle successful WebSubHub operations.
      *
      * @param entity    HTTP entity.
      * @param topic     Topic.
@@ -331,7 +331,7 @@ public class WebSubHubAdapterUtil {
         if (entity != null) {
             String responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
             if (RESPONSE_FOR_SUCCESSFUL_OPERATION.equals(responseString)) {
-                log.debug("Success WebSub Hub operation: " + operation + ", topic: " + topic);
+                log.debug("Success WebSubHub operation: " + operation + ", topic: " + topic);
             } else {
                 throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null,
                         topic, operation, responseString);
@@ -343,7 +343,7 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Handle error responses (e.g., conflict or not found) from WebSub Hub.
+     * Handle error responses (e.g., conflict or not found) from WebSubHub.
      *
      * @param entity    HTTP entity.
      * @param topic     Topic.
@@ -362,7 +362,7 @@ public class WebSubHubAdapterUtil {
     }
 
     /**
-     * Handle failed WebSub Hub operations.
+     * Handle failed WebSubHub operations.
      *
      * @param entity       HTTP entity.
      * @param topic        Topic.

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -350,14 +350,15 @@ public class WebSubHubAdapterUtil {
      * @param operation Operation.
      * @throws IOException If an error occurs while reading the response.
      */
-    public static void handleErrorResponse(HttpEntity entity, String topic, String operation) throws IOException {
+    public static void handleErrorResponse(HttpEntity entity, String topic, String operation)
+            throws IOException, WebSubAdapterServerException {
 
         String responseString = "";
         if (entity != null) {
             responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
         }
-        log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
-                topic, operation, responseString));
+        throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null,
+                topic, operation, responseString);
     }
 
     /**

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -47,9 +47,9 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for the WebSubHubAdapterServiceImpl class.
  */
-public class WebSubHubAdapterServiceImplTest {
+public class WebSubEventPublisherImplTest {
 
-    private WebSubHubAdapterServiceImpl adapterService;
+    private WebSubEventPublisherImpl adapterService;
 
     @Mock
     private ClientManager mockClientManager;
@@ -60,11 +60,13 @@ public class WebSubHubAdapterServiceImplTest {
     @Mock
     private HttpResponse mockHttpResponse;
 
+    MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
+
     @BeforeClass
     public void setUp() {
 
         MockitoAnnotations.openMocks(this);
-        adapterService = spy(new WebSubHubAdapterServiceImpl());
+        adapterService = spy(new WebSubEventPublisherImpl());
 
         MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
         WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -17,46 +18,36 @@
 
 package org.wso2.identity.event.websubhub.publisher.service;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
-import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
-import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
 import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
 import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
-import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Unit tests for the WebSubEventSubscriberImpl class.
  */
 public class WebSubEventSubscriberImplTest {
-
-    private static final Log log = LogFactory.getLog(WebSubEventSubscriberImplTest.class);
 
     private WebSubEventSubscriberImpl subscriberService;
     private AutoCloseable mocks;
@@ -65,152 +56,87 @@ public class WebSubEventSubscriberImplTest {
     private ClientManager mockClientManager;
 
     @Mock
-    private WebSubAdapterConfiguration mockAdapterConfiguration;
+    private CloseableHttpClient mockHttpClient;
 
     @Mock
     private CloseableHttpResponse mockHttpResponse;
 
-    @Mock
-    private StatusLine mockStatusLine;
-
-    @Mock
-    private HttpEntity mockHttpEntity;
-
     private MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
     private MockedStatic<WebSubHubAdapterUtil> mockedStaticUtil;
-    private MockedStatic<WebSubHubCorrelationLogUtils> mockedCorrelationLogUtils;
 
     @BeforeMethod
     public void setUp() {
 
-        log.info("Starting test setup for WebSubEventSubscriberImplTest");
         mocks = MockitoAnnotations.openMocks(this);
         subscriberService = new WebSubEventSubscriberImpl();
-        setupMocks();
-    }
 
-    private void setupMocks() {
+        mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
+        WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
+        when(mockDataHolder.getClientManager()).thenReturn(mockClientManager);
+        mockedStaticDataHolder.when(WebSubHubAdapterDataHolder::getInstance).thenReturn(mockDataHolder);
 
-        try {
-            mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
-            WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
-
-            mockedStaticUtil = mockStatic(WebSubHubAdapterUtil.class);
-            mockedStaticUtil.when(WebSubHubAdapterUtil::getWebSubBaseURL)
-                    .thenReturn("https://mock-websub-hub.com");
-            mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString()))
-                    .thenAnswer(invocation -> invocation.getArgument(1) + "-" +
-                            invocation.getArgument(0));
-            mockedStaticUtil.when(
-                            () -> WebSubHubAdapterUtil.buildSubscriptionURL(anyString(), anyString(), anyString(),
-                                    anyString()))
-                    .thenReturn(
-                            "https://mock-websub-hub.com?hub.mode=subscribe&hub.topic=test-tenant-test-" +
-                                    "uri&hub.callback=https://test-callback.com");
-
-            mockedCorrelationLogUtils = mockStatic(WebSubHubCorrelationLogUtils.class);
-            mockedCorrelationLogUtils.when(() -> WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(any()))
-                    .thenAnswer(invocation -> null);
-
-            when(mockDataHolder.getClientManager()).thenReturn(mockClientManager);
-            when(mockDataHolder.getAdapterConfiguration()).thenReturn(mockAdapterConfiguration);
-            when(mockAdapterConfiguration.getWebSubHubBaseUrl()).thenReturn("https://mock-websub-hub.com");
-
-            when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
-            when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
-        } catch (Exception e) {
-            log.error("Error setting up mocks", e);
-            cleanupMocks();
-            throw e;
-        }
-    }
-
-    private void cleanupMocks() {
-
-        log.info("Cleaning up mocks");
-        try {
-            if (mockedStaticDataHolder != null) {
-                mockedStaticDataHolder.close();
-                mockedStaticDataHolder = null;
-            }
-            if (mockedStaticUtil != null) {
-                mockedStaticUtil.close();
-                mockedStaticUtil = null;
-            }
-            if (mockedCorrelationLogUtils != null) {
-                mockedCorrelationLogUtils.close();
-                mockedCorrelationLogUtils = null;
-            }
-        } catch (Exception e) {
-            log.error("Error closing mocks", e);
-        }
+        mockedStaticUtil = mockStatic(WebSubHubAdapterUtil.class);
+        mockedStaticUtil.when(WebSubHubAdapterUtil::getWebSubBaseURL).thenReturn("https://mock-websub-hub.com");
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(1) + "-" +
+                        invocation.getArgument(0));
+        mockedStaticUtil.when(
+                        () -> WebSubHubAdapterUtil.buildSubscriptionURL(anyString(), anyString(), anyString(),
+                                anyString()))
+                .thenReturn(
+                        "https://mock-websub-hub.com?hub.mode=subscribe&hub.topic=test-topic&hub." +
+                                "callback=https://test-callback.com");
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
 
-        log.info("Tearing down test for WebSubEventSubscriberImplTest");
-        cleanupMocks();
         if (mocks != null) {
             mocks.close();
-            mocks = null;
+        }
+        if (mockedStaticDataHolder != null) {
+            mockedStaticDataHolder.close();
+        }
+        if (mockedStaticUtil != null) {
+            mockedStaticUtil.close();
         }
     }
 
     @Test
-    public void testGetName() {
+    public void testSubscribeSuccess() throws Exception {
 
-        log.info("Testing getName method");
-        // Verify the name matches the expected constant
-        assertEquals(subscriberService.getName(), WEB_SUB_HUB_ADAPTER_NAME);
-    }
-
-    @Test
-    public void testUnsubscribeFailure() throws WebhookMgtException, WebSubAdapterException {
-
-        log.info("Testing unsubscribe failure method");
-        List<String> topics = Arrays.asList("test-uri1", "test-uri2");
+        List<String> topics = Arrays.asList("topic1", "topic2");
         String callbackUrl = "http://test-callback.com";
         String tenantDomain = "test-tenant";
 
-        // Simulate a 500 error for the first topic and 200 for the second
-        CompletableFuture<HttpResponse> failedFuture = CompletableFuture.completedFuture(mockHttpResponse);
-        CompletableFuture<HttpResponse> successFuture = CompletableFuture.completedFuture(mockHttpResponse);
-
-        // Set up the status codes for the responses
-        when(mockStatusLine.getStatusCode()).thenReturn(500).thenReturn(200);
-        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
-        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mock(HttpPost.class));
-        when(mockClientManager.executeAsync(any())).thenReturn(failedFuture).thenReturn(successFuture);
-
-        boolean result = subscriberService.unsubscribe(topics, callbackUrl, tenantDomain);
-
-        // Verify the result is false because one of the unsubscribe requests failed
-        assertFalse(result);
-    }
-
-    @Test
-    public void testSubscribeFailure() throws WebSubAdapterException {
-
-        log.info("Testing subscribe failure method");
-        List<String> topics = Arrays.asList("test-uri1", "test-uri2");
-        String callbackUrl = "http://test-callback.com";
-        String tenantDomain = "test-tenant";
-
-        // Simulate a 500 error for the first topic and 200 for the second
-        CompletableFuture<HttpResponse> failedFuture = CompletableFuture.completedFuture(mockHttpResponse);
-        CompletableFuture<HttpResponse> successFuture = CompletableFuture.completedFuture(mockHttpResponse);
-
-        // Set up the status codes for the responses
-        when(mockStatusLine.getStatusCode()).thenReturn(500).thenReturn(200);
-        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
-        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mock(HttpPost.class));
-        when(mockClientManager.executeAsync(any())).thenReturn(failedFuture).thenReturn(successFuture);
+        HttpPost mockHttpPost = mock(HttpPost.class);
+        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.execute(any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+        when(mockHttpResponse.getStatusLine().getStatusCode()).thenReturn(200);
 
         boolean result = subscriberService.subscribe(topics, callbackUrl, tenantDomain);
 
-        // Verify the result is false because one of the subscribe requests failed
-        assertFalse(result);
+        assertTrue(result);
+        verify(mockClientManager, times(2)).execute(any());
+    }
+
+    @Test
+    public void testUnsubscribeSuccess() throws Exception {
+
+        List<String> topics = Arrays.asList("topic1", "topic2");
+        String callbackUrl = "http://test-callback.com";
+        String tenantDomain = "test-tenant";
+
+        HttpPost mockHttpPost = mock(HttpPost.class);
+        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.execute(any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+        when(mockHttpResponse.getStatusLine().getStatusCode()).thenReturn(200);
+
+        boolean result = subscriberService.unsubscribe(topics, callbackUrl, tenantDomain);
+
+        assertTrue(result);
+        verify(mockClientManager, times(2)).execute(any());
     }
 }
-

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.websubhub.publisher.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
+import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
+import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
+import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME;
+
+/**
+ * Unit tests for the WebSubEventSubscriberImpl class.
+ */
+public class WebSubEventSubscriberImplTest {
+
+    private static final Log log = LogFactory.getLog(WebSubEventSubscriberImplTest.class);
+
+    private WebSubEventSubscriberImpl subscriberService;
+    private AutoCloseable mocks;
+
+    @Mock
+    private ClientManager mockClientManager;
+
+    @Mock
+    private WebSubAdapterConfiguration mockAdapterConfiguration;
+
+    @Mock
+    private CloseableHttpResponse mockHttpResponse;
+
+    @Mock
+    private StatusLine mockStatusLine;
+
+    @Mock
+    private HttpEntity mockHttpEntity;
+
+    private MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
+    private MockedStatic<WebSubHubAdapterUtil> mockedStaticUtil;
+    private MockedStatic<WebSubHubCorrelationLogUtils> mockedCorrelationLogUtils;
+
+    private WebSubHubAdapterDataHolder mockDataHolder;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        log.info("Starting test setup for WebSubEventSubscriberImplTest");
+        mocks = MockitoAnnotations.openMocks(this);
+        subscriberService = new WebSubEventSubscriberImpl();
+        setupMocks();
+    }
+
+    private void setupMocks() throws WebSubAdapterException {
+
+        try {
+            mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
+            mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
+            mockedStaticDataHolder.when(WebSubHubAdapterDataHolder::getInstance).thenReturn(mockDataHolder);
+
+            mockedStaticUtil = mockStatic(WebSubHubAdapterUtil.class);
+            mockedStaticUtil.when(() -> WebSubHubAdapterUtil.getWebSubBaseURL())
+                    .thenReturn("http://mock-websub-hub.com");
+            mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString()))
+                    .thenAnswer(invocation -> invocation.getArgument(1) + "-" +
+                            invocation.getArgument(0));
+            mockedStaticUtil.when(
+                            () -> WebSubHubAdapterUtil.buildSubscriptionURL(anyString(), anyString(), anyString(),
+                                    anyString()))
+                    .thenReturn(
+                            "http://mock-websub-hub.com?hub.mode=subscribe&hub.topic=test-tenant-test-" +
+                                    "uri&hub.callback=http://test-callback.com");
+
+            mockedCorrelationLogUtils = mockStatic(WebSubHubCorrelationLogUtils.class);
+            mockedCorrelationLogUtils.when(() -> WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(any()))
+                    .thenAnswer(invocation -> null);
+
+            when(mockDataHolder.getClientManager()).thenReturn(mockClientManager);
+            when(mockDataHolder.getAdapterConfiguration()).thenReturn(mockAdapterConfiguration);
+            when(mockAdapterConfiguration.getWebSubHubBaseUrl()).thenReturn("http://mock-websub-hub.com");
+
+            when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+            when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        } catch (Exception e) {
+            log.error("Error setting up mocks", e);
+            cleanupMocks();
+            throw e;
+        }
+    }
+
+    private void cleanupMocks() {
+
+        log.info("Cleaning up mocks");
+        try {
+            if (mockedStaticDataHolder != null) {
+                mockedStaticDataHolder.close();
+                mockedStaticDataHolder = null;
+            }
+            if (mockedStaticUtil != null) {
+                mockedStaticUtil.close();
+                mockedStaticUtil = null;
+            }
+            if (mockedCorrelationLogUtils != null) {
+                mockedCorrelationLogUtils.close();
+                mockedCorrelationLogUtils = null;
+            }
+        } catch (Exception e) {
+            log.error("Error closing mocks", e);
+        }
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        log.info("Tearing down test for WebSubEventSubscriberImplTest");
+        cleanupMocks();
+        if (mocks != null) {
+            mocks.close();
+            mocks = null;
+        }
+    }
+
+    @Test
+    public void testGetName() {
+
+        log.info("Testing getName method");
+        // Verify the name matches the expected constant
+        assertEquals(subscriberService.getName(), WEB_SUB_HUB_ADAPTER_NAME);
+    }
+
+    @Test
+    public void testSubscribeSuccess()
+            throws WebhookMgtException, WebSubAdapterException {
+
+        log.info("Testing subscribe success method");
+        List<String> topics = Arrays.asList("test-uri1", "test-uri2");
+        String callbackUrl = "http://test-callback.com";
+        String tenantDomain = "test-tenant";
+
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        CompletableFuture<HttpResponse> future = CompletableFuture.completedFuture(mockHttpResponse);
+        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mock(HttpPost.class));
+        when(mockClientManager.executeAsync(any())).thenReturn(future);
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleSuccessfulOperation(any(), anyString(), anyString()))
+                .thenAnswer(invocation -> null);
+
+        // Execute and verify
+        boolean result = subscriberService.subscribe(topics, callbackUrl, tenantDomain);
+
+        // Verify the result is true and the client was called twice (once for each topic)
+        assertTrue(result);
+        verify(mockClientManager, times(2)).executeAsync(any());
+    }
+
+    @Test
+    public void testUnsubscribeSuccess() throws WebhookMgtException, WebSubAdapterException {
+
+        log.info("Testing unsubscribe success method");
+        List<String> topics = Arrays.asList("test-uri1", "test-uri2");
+        String callbackUrl = "http://test-callback.com";
+        String tenantDomain = "test-tenant";
+
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        CompletableFuture<HttpResponse> future = CompletableFuture.completedFuture(mockHttpResponse);
+        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mock(HttpPost.class));
+        when(mockClientManager.executeAsync(any())).thenReturn(future);
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleSuccessfulOperation(any(), anyString(), anyString()))
+                .thenAnswer(invocation -> null);
+
+        // Execute and verify
+        boolean result = subscriberService.unsubscribe(topics, callbackUrl, tenantDomain);
+
+        // Verify the result is true and the client was called twice (once for each topic)
+        assertTrue(result);
+        verify(mockClientManager, times(2)).executeAsync(any());
+    }
+}
+

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/resources/testng.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/resources/testng.xml
@@ -20,8 +20,9 @@
 
     <test name="WebSubHubEventAdapterTests" preserve-order="true" parallel="false">
         <classes>
+            <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubEventSubscriberImplTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.internal.ClientManagerTest"/>
-            <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubHubAdapterServiceImplTest"/>
+            <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubEventPublisherImplTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.config.OutboundAdapterConfigurationProviderTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfigurationTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtilTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.webhook.management</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.33</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.164</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request



This pull request introduces enhancements to the WebSubHub adapter by adding support for webhook subscription management. Key changes include updates to dependencies, new constants, interface implementation for subscription handling, and methods for managing subscriptions.

### Dependency Updates:
* Added `org.wso2.carbon.identity.webhook.management` as a dependency in `pom.xml` to enable webhook management functionality. (`[[1]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R58-R61)`, `[[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R71-R75)`)

### Constants and Configuration:
* Introduced new constants in `WebSubHubAdapterConstants.java`, including `WEB_SUB_HUB_ADAPTER_NAME`, `HUB_CALLBACK`, `SUBSCRIBE`, and `UNSUBSCRIBE`, to support subscription management operations. (`[[1]](diffhunk://#diff-fb24c2667f4eca69c5aee88c9fd2e68e28f168653932fc78dff932f3f3a9214bR26)`, `[[2]](diffhunk://#diff-fb24c2667f4eca69c5aee88c9fd2e68e28f168653932fc78dff932f3f3a9214bR45-R51)`)

### Subscription Management Implementation:
* Updated `WebSubHubAdapterServiceImpl` to implement the `WebhookSubscriber` interface, adding methods `subscribe` and `unsubscribe` for managing webhook subscriptions. (`[[1]](diffhunk://#diff-a191dd2ec97faa2a3d211e18c0acc0ba41fa94a70920f7f1a7f02f7a6c534ebdL72-R80)`, `[[2]](diffhunk://#diff-a191dd2ec97faa2a3d211e18c0acc0ba41fa94a70920f7f1a7f02f7a6c534ebdR94-R134)`)
* Added a private method `makeSubscriptionMgtAPICall` to handle subscription API calls and a helper method `buildSubscriptionURL` to construct subscription URLs. (`[[1]](diffhunk://#diff-a191dd2ec97faa2a3d211e18c0acc0ba41fa94a70920f7f1a7f02f7a6c534ebdR223-R238)`, `[[2]](diffhunk://#diff-a191dd2ec97faa2a3d211e18c0acc0ba41fa94a70920f7f1a7f02f7a6c534ebdL203-R289)`)

### Additional Improvements:
* Refactored the topic management API response handler to be reused for subscription management. (`[components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubHubAdapterServiceImpl.javaL193-R254](diffhunk://#diff-a191dd2ec97faa2a3d211e18c0acc0ba41fa94a70920f7f1a7f02f7a6c534ebdL193-R254)`)