### PR TITLE
Added topic manager implementation to the publisher

### DIFF
--- a/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/EventContext.java
+++ b/components/org.wso2.identity.event.common.publisher/src/main/java/org/wso2/identity/event/common/publisher/model/EventContext.java
@@ -25,11 +25,13 @@ public class EventContext {
 
     private final String tenantDomain;
     private final String eventUri;
+    private final String eventProfileVersion;
 
     private EventContext(Builder builder) {
 
         this.tenantDomain = builder.tenantDomain;
         this.eventUri = builder.eventUri;
+        this.eventProfileVersion = builder.eventProfileVersion;
     }
 
     public String getTenantDomain() {
@@ -40,6 +42,11 @@ public class EventContext {
     public String getEventUri() {
 
         return eventUri;
+    }
+
+    public String getEventProfileVersion() {
+
+        return eventProfileVersion;
     }
 
     public static Builder builder() {
@@ -54,8 +61,11 @@ public class EventContext {
 
         private String tenantDomain;
         private String eventUri;
+        private String eventProfileVersion;
 
-        public Builder() {}
+        public Builder() {
+
+        }
 
         public Builder tenantDomain(String tenantDomain) {
 
@@ -66,6 +76,12 @@ public class EventContext {
         public Builder eventUri(String eventUri) {
 
             this.eventUri = eventUri;
+            return this;
+        }
+
+        public Builder eventProfileVersion(String eventProfileVersion) {
+
+            this.eventProfileVersion = eventProfileVersion;
             return this;
         }
 

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
@@ -228,13 +228,6 @@ public class EventPublisherServiceTest {
     }
 
     @Test
-    public void testEventPublisherServiceWithNullPayload() {
-
-        eventPublisherService.publish(null, mockEventContext);
-        verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
-    }
-
-    @Test
     public void testSecurityEventTokenPayloadWithSubId() {
 
         Map<String, EventPayload> eventMap = new HashMap<>();

--- a/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
+++ b/components/org.wso2.identity.event.common.publisher/src/test/java/org/wso2/identity/event/common/publisher/EventPublisherServiceTest.java
@@ -147,10 +147,12 @@ public class EventPublisherServiceTest {
         EventContext eventContext = EventContext.builder()
                 .tenantDomain("example.com")
                 .eventUri("http://example.com/event")
+                .eventProfileVersion("1.0.0")
                 .build();
 
         Assert.assertEquals(eventContext.getTenantDomain(), "example.com");
         Assert.assertEquals(eventContext.getEventUri(), "http://example.com/event");
+        Assert.assertEquals(eventContext.getEventProfileVersion(), "1.0.0");
     }
 
     @Test
@@ -223,14 +225,6 @@ public class EventPublisherServiceTest {
         Assert.assertEquals(payload.getRci(), "rci123");
         Assert.assertNotNull(payload.getEvents());
         Assert.assertTrue(payload.getEvents().isEmpty());
-    }
-
-    @Test
-    public void testEventPublisherServiceWithEmptyPublishers() {
-
-        EventPublisherDataHolder.getInstance().setEventPublishers(Collections.emptyList());
-        eventPublisherService.publish(mockEventPayload, mockEventContext);
-        verifyNoInteractions(mockEventPublisher1, mockEventPublisher2);
     }
 
     @Test

--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>org.wso2.carbon.identity.webhook.management</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.topic.management</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.identity.event.publishers</groupId>
             <artifactId>org.wso2.identity.event.common.publisher</artifactId>
         </dependency>
@@ -113,6 +117,7 @@
                             org.apache.http.impl.nio.conn; version="${httpasyncclient.version.range}",
                             org.apache.http.impl.nio.reactor; version="${httpasyncclient.version.range}",
                             org.apache.http.impl.nio.client; version="${httpasyncclient.version.range}",
+                            org.apache.http.impl.conn; version="${httpasyncclient.version.range}",
                             org.apache.http.impl.client; version="${httpasyncclient.version.range}",
                             org.apache.http.nio.conn; version="${httpasyncclient.version.range}",
                             org.apache.http.nio.reactor; version="${httpasyncclient.version.range}",
@@ -120,9 +125,12 @@
                             org.apache.http.client.methods; version="${httpasyncclient.version.range}",
                             org.apache.http.entity; version="${httpasyncclient.version.range}",
                             org.apache.http.client.config; version="${httpasyncclient.version.range}",
+                            org.apache.http.client.entity; version="${httpasyncclient.version.range}",
+                            org.apache.http.conn; version="${httpasyncclient.version.range}",
                             org.apache.http.conn.ssl; version="${httpasyncclient.version.range}",
                             org.apache.http.util; version="${httpasyncclient.version.range}",
                             org.apache.http.ssl; version="${httpasyncclient.version.range}",
+                            org.apache.http.message; version="${httpasyncclient.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception;
@@ -131,7 +139,9 @@
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.webhook.management.api;
+                            org.wso2.carbon.identity.webhook.management.api.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.topic.management.api.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.json.simple.parser; version="${com.googlecode.json-simple.wso2.version.range}",
                             org.wso2.identity.event.common.publisher;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -42,7 +42,8 @@ public class WebSubHubAdapterConstants {
      */
     public static class Http {
 
-        public static final String TOPIC_SEPARATOR = "-";
+        public static final String TOPIC_SEPARATOR = ".";
+        public static final String REGEX_HTTP_OR_HTTPS_PREFIX = "^https?://";
         public static final String URL_PARAM_SEPARATOR = "&";
         public static final String URL_KEY_VALUE_SEPARATOR = "=";
         public static final String PUBLISH = "publish";

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -20,11 +20,8 @@ package org.wso2.identity.event.websubhub.publisher.service;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -32,37 +29,22 @@ import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.identity.event.common.publisher.EventPublisher;
 import org.wso2.identity.event.common.publisher.model.EventContext;
 import org.wso2.identity.event.common.publisher.model.SecurityEventTokenPayload;
-import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
 import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
 import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.DEREGISTER;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_ACTIVE_SUBS;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_REASON;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.PUBLISH;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.REGISTER;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleClientException;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleErrorResponse;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleFailedOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleResponseCorrelationLog;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleServerException;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logDiagnosticFailure;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logDiagnosticSuccess;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.logPublishingEvent;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.parseEventHubResponse;
 
 /**
  * OSGi service for publishing events using web sub hub.
@@ -76,36 +58,9 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             throws WebSubAdapterException {
 
         makeAsyncAPICall(eventPayload, eventContext,
-                constructHubTopic(eventContext.getEventUri(), eventContext.getTenantDomain()), getWebSubBaseURL());
+                constructHubTopic(eventContext.getEventUri(), eventContext.getEventProfileVersion(),
+                        eventContext.getTenantDomain()), getWebSubBaseURL());
         log.debug("Event published successfully to the WebSubHub.");
-    }
-
-    /**
-     * Register a topic in the WebSubHub.
-     *
-     * @param eventUri     Event URI.
-     * @param tenantDomain Tenant domain.
-     * @throws WebSubAdapterException If an error occurs while registering the topic.
-     */
-    public void registerTopic(String eventUri, String tenantDomain) throws WebSubAdapterException {
-
-        makeTopicMgtAPICall(constructHubTopic(eventUri, tenantDomain), getWebSubBaseURL(),
-                WebSubHubAdapterConstants.Http.REGISTER, tenantDomain);
-        log.debug("WebSubHub Topic registered successfully for the event: " + eventUri + " in tenant: " +
-                tenantDomain);
-    }
-
-    /**
-     * Deregister a topic in the WebSubHub.
-     *
-     * @param eventUri     Event URI.
-     * @param tenantDomain Tenant domain.
-     * @throws WebSubAdapterException If an error occurs while deregistering the topic.
-     */
-    public void deregisterTopic(String eventUri, String tenantDomain) throws WebSubAdapterException {
-
-        makeTopicMgtAPICall(constructHubTopic(eventUri, tenantDomain),
-                getWebSubBaseURL(), DEREGISTER, tenantDomain);
     }
 
     private void makeAsyncAPICall(SecurityEventTokenPayload eventPayload, EventContext eventContext,
@@ -131,57 +86,6 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                     log.error("Publishing event data to WebSubHub failed. ", ex);
                     throw new IdentityRuntimeException("Error occurred while publishing event data to WebSubHub. ", ex);
                 });
-    }
-
-    private void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
-            throws WebSubAdapterException {
-
-        String topicMgtUrl = buildURL(topic, webSubHubBaseUrl, operation);
-
-        ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
-        HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null);
-
-        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
-        final long requestStartTime = System.currentTimeMillis();
-
-        try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.execute(httpPost)) {
-            handleTopicMgtResponse(response, httpPost, topic, operation, requestStartTime);
-        } catch (IOException | WebSubAdapterException e) {
-            throw handleServerException(ERROR_REGISTERING_HUB_TOPIC, e, topic, tenantDomain);
-        }
-    }
-
-    private void handleTopicMgtResponse(CloseableHttpResponse response, HttpPost httpPost,
-                                        String topic, String operation, long requestStartTime)
-            throws IOException, WebSubAdapterException {
-
-        StatusLine statusLine = response.getStatusLine();
-        int responseCode = statusLine.getStatusCode();
-        String responsePhrase = statusLine.getReasonPhrase();
-
-        if (responseCode == HttpStatus.SC_OK) {
-            HttpEntity entity = response.getEntity();
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            handleSuccessfulOperation(entity, topic, operation);
-        } else if ((responseCode == HttpStatus.SC_CONFLICT && operation.equals(REGISTER)) ||
-                (responseCode == HttpStatus.SC_NOT_FOUND && operation.equals(DEREGISTER))) {
-            HttpEntity entity = response.getEntity();
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            handleErrorResponse(entity, topic, operation);
-        } else {
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            if (responseCode == HttpStatus.SC_FORBIDDEN) {
-                handleForbiddenResponse(response, topic);
-            }
-            HttpEntity entity = response.getEntity();
-            handleFailedOperation(entity, topic, operation, responseCode);
-        }
     }
 
     private static void handleAsyncResponse(HttpResponse response, HttpPost request, long requestStartTime,
@@ -228,21 +132,6 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             }
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
-        }
-    }
-
-    private static void handleForbiddenResponse(CloseableHttpResponse response, String topic) throws IOException,
-            WebSubAdapterException {
-
-        Map<String, String> hubResponse = parseEventHubResponse(response);
-        if (!hubResponse.isEmpty() && hubResponse.containsKey(HUB_REASON)) {
-            String errorMsg = String.format(ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, topic);
-            if (errorMsg.equals(hubResponse.get(HUB_REASON))) {
-                log.debug(String.format(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS.getDescription(),
-                        topic, hubResponse.get(HUB_ACTIVE_SUBS)));
-                throw handleClientException(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS, topic,
-                        hubResponse.get(HUB_ACTIVE_SUBS));
-            }
         }
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.websubhub.publisher.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
+import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
+import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
+import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
+import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_DEREGISTERING_HUB_TOPIC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.DEREGISTER;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_ACTIVE_SUBS;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_REASON;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.REGISTER;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleClientException;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleErrorResponse;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleFailedOperation;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleServerException;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleTopicMgtException;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.parseEventHubResponse;
+
+/**
+ * OSGi service for register topics using web sub hub.
+ */
+public class WebSubTopicManagerImpl implements TopicManager {
+
+    private static final Log log = LogFactory.getLog(WebSubTopicManagerImpl.class);
+
+    @Override
+    public String getName() {
+
+        return WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME;
+    }
+
+    @Override
+    public String constructTopic(String channelUri, String eventProfileVersion, String tenantDomain)
+            throws TopicManagementException {
+
+        return constructHubTopic(channelUri, eventProfileVersion, tenantDomain);
+    }
+
+    @Override
+    public void registerTopic(String topic, String tenantDomain) throws TopicManagementException {
+
+        try {
+            makeTopicMgtAPICall(topic, getWebSubBaseURL(),
+                    WebSubHubAdapterConstants.Http.REGISTER, tenantDomain);
+            log.debug("WebSubHub Topic registered successfully for the topic: " + topic + " in tenant: " +
+                    tenantDomain);
+        } catch (WebSubAdapterException e) {
+            throw handleTopicMgtException(ERROR_REGISTERING_HUB_TOPIC, e, topic, tenantDomain);
+        }
+    }
+
+    @Override
+    public void deregisterTopic(String topic, String tenantDomain) throws TopicManagementException {
+
+        try {
+            makeTopicMgtAPICall(topic, getWebSubBaseURL(),
+                    WebSubHubAdapterConstants.Http.DEREGISTER, tenantDomain);
+            log.debug("WebSubHub Topic deregistered successfully for the topic: " + topic + " in tenant: " +
+                    tenantDomain);
+        } catch (WebSubAdapterException e) {
+            throw handleTopicMgtException(ERROR_DEREGISTERING_HUB_TOPIC, e, topic, tenantDomain);
+        }
+    }
+
+    private void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
+            throws WebSubAdapterException {
+
+        String topicMgtUrl = buildURL(topic, webSubHubBaseUrl, operation);
+
+        ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
+        HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null);
+
+        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
+        final long requestStartTime = System.currentTimeMillis();
+
+        try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.execute(httpPost)) {
+            handleTopicMgtResponse(response, httpPost, topic, operation, requestStartTime);
+        } catch (IOException | WebSubAdapterException e) {
+            throw handleServerException(ERROR_REGISTERING_HUB_TOPIC, e, topic, tenantDomain);
+        }
+    }
+
+    private void handleTopicMgtResponse(CloseableHttpResponse response, HttpPost httpPost,
+                                        String topic, String operation, long requestStartTime)
+            throws IOException, WebSubAdapterException {
+
+        StatusLine statusLine = response.getStatusLine();
+        int responseCode = statusLine.getStatusCode();
+        String responsePhrase = statusLine.getReasonPhrase();
+
+        if (responseCode == HttpStatus.SC_OK) {
+            HttpEntity entity = response.getEntity();
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            handleSuccessfulOperation(entity, topic, operation);
+        } else if ((responseCode == HttpStatus.SC_CONFLICT && operation.equals(REGISTER)) ||
+                (responseCode == HttpStatus.SC_NOT_FOUND && operation.equals(DEREGISTER))) {
+            HttpEntity entity = response.getEntity();
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            handleErrorResponse(entity, topic, operation);
+        } else {
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                    WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
+                    String.valueOf(responseCode), responsePhrase);
+            if (responseCode == HttpStatus.SC_FORBIDDEN) {
+                handleForbiddenResponse(response, topic);
+            }
+            HttpEntity entity = response.getEntity();
+            handleFailedOperation(entity, topic, operation, responseCode);
+        }
+    }
+
+    private static void handleForbiddenResponse(CloseableHttpResponse response, String topic) throws IOException,
+            WebSubAdapterException {
+
+        Map<String, String> hubResponse = parseEventHubResponse(response);
+        if (!hubResponse.isEmpty() && hubResponse.containsKey(HUB_REASON)) {
+            String errorMsg = String.format(ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, topic);
+            if (errorMsg.equals(hubResponse.get(HUB_REASON))) {
+                log.debug(String.format(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS.getDescription(),
+                        topic, hubResponse.get(HUB_ACTIVE_SUBS)));
+                throw handleClientException(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS, topic,
+                        hubResponse.get(HUB_ACTIVE_SUBS));
+            }
+        }
+    }
+}

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
 import org.wso2.identity.event.common.publisher.model.EventContext;
 import org.wso2.identity.event.common.publisher.model.SecurityEventTokenPayload;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.when;
 public class WebSubEventPublisherImplTest {
 
     private WebSubEventPublisherImpl adapterService;
+    private WebSubTopicManagerImpl webSubTopicManager;
 
     @Mock
     private ClientManager mockClientManager;
@@ -67,6 +69,7 @@ public class WebSubEventPublisherImplTest {
 
         MockitoAnnotations.openMocks(this);
         adapterService = spy(new WebSubEventPublisherImpl());
+        webSubTopicManager = spy(new WebSubTopicManagerImpl());
 
         MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
         WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
@@ -108,42 +111,42 @@ public class WebSubEventPublisherImplTest {
     }
 
     @Test
-    public void testRegisterTopic() throws WebSubAdapterException {
+    public void testRegisterTopic() throws TopicManagementException {
 
-        doNothing().when(adapterService).registerTopic("test-uri", "test-tenant");
+        doNothing().when(webSubTopicManager).registerTopic("test-uri", "test-tenant");
 
-        adapterService.registerTopic("test-uri", "test-tenant");
+        webSubTopicManager.registerTopic("test-uri", "test-tenant");
 
-        verify(adapterService, times(1)).registerTopic("test-uri",
+        verify(webSubTopicManager, times(1)).registerTopic("test-uri",
                 "test-tenant");
     }
 
-    @Test(expectedExceptions = WebSubAdapterException.class)
-    public void testRegisterTopicFailure() throws WebSubAdapterException {
+    @Test(expectedExceptions = TopicManagementException.class)
+    public void testRegisterTopicFailure() throws TopicManagementException {
 
-        doThrow(new WebSubAdapterException("Registration failed", "Description", "ErrorCode"))
-                .when(adapterService).registerTopic("test-uri", "test-tenant");
+        doThrow(new TopicManagementException("Registration failed", "Description", "ErrorCode"))
+                .when(webSubTopicManager).registerTopic("test-uri", "test-tenant");
 
-        adapterService.registerTopic("test-uri", "test-tenant");
+        webSubTopicManager.registerTopic("test-uri", "test-tenant");
     }
 
     @Test
-    public void testDeregisterTopic() throws WebSubAdapterException {
+    public void testDeregisterTopic() throws TopicManagementException {
 
-        doNothing().when(adapterService).deregisterTopic("test-uri", "test-tenant");
+        doNothing().when(webSubTopicManager).deregisterTopic("test-uri", "test-tenant");
 
-        adapterService.deregisterTopic("test-uri", "test-tenant");
+        webSubTopicManager.deregisterTopic("test-uri", "test-tenant");
 
-        verify(adapterService, times(1)).deregisterTopic("test-uri",
+        verify(webSubTopicManager, times(1)).deregisterTopic("test-uri",
                 "test-tenant");
     }
 
-    @Test(expectedExceptions = WebSubAdapterException.class)
-    public void testDeregisterTopicFailure() throws WebSubAdapterException {
+    @Test(expectedExceptions = TopicManagementException.class)
+    public void testDeregisterTopicFailure() throws TopicManagementException {
 
-        doThrow(new WebSubAdapterException("Deregistration failed", "Description", "ErrorCode"))
-                .when(adapterService).deregisterTopic("test-uri", "test-tenant");
+        doThrow(new TopicManagementException("Deregistration failed", "Description", "ErrorCode"))
+                .when(webSubTopicManager).deregisterTopic("test-uri", "test-tenant");
 
-        adapterService.deregisterTopic("test-uri", "test-tenant");
+        webSubTopicManager.deregisterTopic("test-uri", "test-tenant");
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -21,7 +21,6 @@ package org.wso2.identity.event.websubhub.publisher.service;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -54,9 +53,6 @@ public class WebSubEventSubscriberImplTest {
 
     @Mock
     private ClientManager mockClientManager;
-
-    @Mock
-    private CloseableHttpClient mockHttpClient;
 
     @Mock
     private CloseableHttpResponse mockHttpResponse;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -77,15 +77,9 @@ public class WebSubEventSubscriberImplTest {
 
         mockedStaticUtil = mockStatic(WebSubHubAdapterUtil.class);
         mockedStaticUtil.when(WebSubHubAdapterUtil::getWebSubBaseURL).thenReturn("https://mock-websub-hub.com");
-        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString()))
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString(), anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(1) + "-" +
                         invocation.getArgument(0));
-        mockedStaticUtil.when(
-                        () -> WebSubHubAdapterUtil.buildSubscriptionURL(anyString(), anyString(), anyString(),
-                                anyString()))
-                .thenReturn(
-                        "https://mock-websub-hub.com?hub.mode=subscribe&hub.topic=test-topic&hub." +
-                                "callback=https://test-callback.com");
     }
 
     @AfterMethod

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.event.websubhub.publisher.service;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
+import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
+import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterClientException;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
+import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterServerException;
+import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
+import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
+import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.ACCEPTED;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_MODE;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME;
+
+/**
+ * Unit tests for the WebSubTopicManagerImpl class.
+ */
+public class WebSubTopicManagerImplTest {
+
+    private WebSubTopicManagerImpl webSubTopicManager;
+    private AutoCloseable mocks;
+
+    @Mock
+    private ClientManager mockClientManager;
+
+    @Mock
+    private WebSubAdapterConfiguration mockAdapterConfiguration;
+
+    @Mock
+    private CloseableHttpResponse mockHttpResponse;
+
+    @Mock
+    private HttpEntity mockEntity;
+
+    @Mock
+    private StatusLine mockStatusLine;
+
+    @Mock
+    private HttpPost mockHttpPost;
+
+    private MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
+    private MockedStatic<WebSubHubAdapterUtil> mockedStaticUtil;
+    private MockedStatic<WebSubHubCorrelationLogUtils> mockedStaticCorrelationLogUtils;
+
+    @BeforeMethod
+    public void setUp() throws WebSubAdapterException, IOException {
+
+        mocks = MockitoAnnotations.openMocks(this);
+        webSubTopicManager = new WebSubTopicManagerImpl();
+
+        mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
+        WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
+        when(mockDataHolder.getClientManager()).thenReturn(mockClientManager);
+        when(mockDataHolder.getAdapterConfiguration()).thenReturn(mockAdapterConfiguration);
+        mockedStaticDataHolder.when(WebSubHubAdapterDataHolder::getInstance).thenReturn(mockDataHolder);
+
+        mockedStaticUtil = mockStatic(WebSubHubAdapterUtil.class);
+        mockedStaticUtil.when(WebSubHubAdapterUtil::getWebSubBaseURL).thenReturn("https://hub.example.com");
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.buildURL(anyString(), anyString(), anyString()))
+                .thenReturn("https://hub.example.com?hub.mode=register&hub.topic=test-topic");
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.constructHubTopic(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    String channelUri = invocation.getArgument(0);
+                    String profileVersion = invocation.getArgument(1);
+                    String tenantDomain = invocation.getArgument(2);
+                    return tenantDomain + "." + profileVersion + "." + channelUri;
+                });
+
+        mockedStaticCorrelationLogUtils = mockStatic(WebSubHubCorrelationLogUtils.class);
+        mockedStaticCorrelationLogUtils.when(() ->
+                        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(any(HttpPost.class)))
+                .thenAnswer(invocation -> null);
+
+        mockedStaticCorrelationLogUtils.when(() ->
+                        WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(
+                                any(HttpPost.class), anyLong(), anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> null);
+
+        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockHttpResponse.getEntity()).thenReturn(mockEntity);
+
+        String responseContent = HUB_MODE + "=" + ACCEPTED;
+        when(mockEntity.getContent()).thenReturn(
+                new ByteArrayInputStream(responseContent.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        if (mockedStaticCorrelationLogUtils != null) {
+            mockedStaticCorrelationLogUtils.close();
+        }
+        if (mockedStaticUtil != null) {
+            mockedStaticUtil.close();
+        }
+        if (mockedStaticDataHolder != null) {
+            mockedStaticDataHolder.close();
+        }
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    public void testGetName() {
+
+        assertEquals(webSubTopicManager.getName(), WEB_SUB_HUB_ADAPTER_NAME);
+    }
+
+    @Test
+    public void testConstructTopic() throws TopicManagementException {
+
+        String topic = webSubTopicManager.constructTopic("channel-uri", "1.0",
+                "carbon.super");
+
+        assertEquals(topic, "carbon.super.1.0.channel-uri");
+
+        mockedStaticUtil.verify(() ->
+                WebSubHubAdapterUtil.constructHubTopic("channel-uri", "1.0",
+                        "carbon.super"));
+    }
+
+    @Test
+    public void testRegisterTopicSuccess() throws TopicManagementException, WebSubAdapterException {
+        // Setup success response
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        // Execute the method
+        webSubTopicManager.registerTopic("test-topic", "carbon.super");
+
+        // Verify interactions
+        verify(mockClientManager).createHttpPost(anyString(), any());
+        verify(mockClientManager).execute(any(HttpPost.class));
+    }
+
+    @Test
+    public void testDeregisterTopicSuccess() throws TopicManagementException, WebSubAdapterException {
+
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        webSubTopicManager.deregisterTopic("test-topic", "carbon.super");
+
+        verify(mockClientManager).createHttpPost(anyString(), any());
+        verify(mockClientManager).execute(any(HttpPost.class));
+
+        mockedStaticCorrelationLogUtils.verify(() ->
+                WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(any(HttpPost.class)));
+        mockedStaticUtil.verify(() ->
+                WebSubHubAdapterUtil.handleSuccessfulOperation(any(), eq("test-topic"), eq("deregister")));
+    }
+
+    @Test(expectedExceptions = TopicManagementException.class)
+    public void testRegisterTopicFailure() throws TopicManagementException {
+
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        when(mockStatusLine.getReasonPhrase()).thenReturn("Internal Server Error");
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleFailedOperation(
+                        any(), anyString(), anyString(), eq(HttpStatus.SC_INTERNAL_SERVER_ERROR)))
+                .thenThrow(new WebSubAdapterException("Error", "Failed operation"));
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleClientException(
+                        eq(WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS),
+                        any(), any()))
+                .thenReturn(new WebSubAdapterClientException("Error message", "Description", "ERROR_CODE"));
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleServerException(
+                        eq(WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC),
+                        any(), any()))
+                .thenReturn(new WebSubAdapterServerException("Error message", "Description"));
+
+        mockedStaticUtil.when(
+                        () -> WebSubHubAdapterUtil.handleTopicMgtException(
+                                eq(ERROR_REGISTERING_HUB_TOPIC),
+                                any(),
+                                anyString(),
+                                anyString()
+                        ))
+                .thenReturn(new TopicManagementException("Error", "Description", "CODE"));
+
+        // Execute the method - should throw exception
+        webSubTopicManager.registerTopic("test-topic", "carbon.super");
+    }
+
+    @Test(expectedExceptions = TopicManagementException.class)
+    public void testDeregisterTopicWithActiveSubscribersFailure() throws TopicManagementException {
+
+        when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_FORBIDDEN);
+        when(mockStatusLine.getReasonPhrase()).thenReturn("Forbidden");
+
+        java.util.Map<String, String> responseMap = new java.util.HashMap<>();
+        responseMap.put(WebSubHubAdapterConstants.Http.HUB_REASON,
+                String.format(WebSubHubAdapterConstants.Http.ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, "test-topic"));
+        responseMap.put(WebSubHubAdapterConstants.Http.HUB_ACTIVE_SUBS, "3");
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.parseEventHubResponse(any()))
+                .thenReturn(responseMap);
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleClientException(
+                        eq(WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS),
+                        any(), any()))
+                .thenReturn(new WebSubAdapterClientException("Error message", "Description", "ERROR_CODE"));
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleServerException(
+                        eq(WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC),
+                        any(), any()))
+                .thenReturn(new WebSubAdapterServerException("Error message", "Description"));
+
+        mockedStaticUtil.when(() -> WebSubHubAdapterUtil.handleTopicMgtException(any(), any(), any(), any()))
+                .thenReturn(new TopicManagementException("Error", "Description", "CODE"));
+
+        webSubTopicManager.deregisterTopic("test-topic", "carbon.super");
+    }
+}

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/resources/testng.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
             <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubEventSubscriberImplTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.internal.ClientManagerTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubEventPublisherImplTest"/>
+            <class name="org.wso2.identity.event.websubhub.publisher.service.WebSubTopicManagerImplTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.config.OutboundAdapterConfigurationProviderTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfigurationTest"/>
             <class name="org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtilTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.topic.management</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <exclusions>
@@ -374,7 +379,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.164</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.203</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces several changes to enhance the functionality and simplify the codebase of the WebSubHub event publishing and subscription modules. Key updates include the addition of an `eventProfileVersion` field in the `EventContext` class, modifications to topic management and subscription handling, and updates to dependency configurations in the `pom.xml` file.

### Enhancements to `EventContext`:

* Added a new field `eventProfileVersion` to the `EventContext` class to support versioning for event profiles. This includes updates to the constructor, getter method, and builder pattern. (`EventContext.java`, [[1]](diffhunk://#diff-c088e5a2fa7ad1b6b641b613e10577632e7dae33e841f2f14f8146e7caa4c303R28-R34) [[2]](diffhunk://#diff-c088e5a2fa7ad1b6b641b613e10577632e7dae33e841f2f14f8146e7caa4c303R47-R51) [[3]](diffhunk://#diff-c088e5a2fa7ad1b6b641b613e10577632e7dae33e841f2f14f8146e7caa4c303R64-R68) [[4]](diffhunk://#diff-c088e5a2fa7ad1b6b641b613e10577632e7dae33e841f2f14f8146e7caa4c303R82-R87)

### Updates to WebSubHub Publisher:

* Removed methods related to topic registration and deregistration (`registerTopic`, `deregisterTopic`, and `makeTopicMgtAPICall`) from `WebSubEventPublisherImpl`, simplifying the class and focusing on event publishing. (`WebSubEventPublisherImpl.java`, [[1]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL79-L110) [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL136-L186)
* Updated the `publish` method to use the new `eventProfileVersion` field when constructing hub topics. (`WebSubEventPublisherImpl.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.javaL79-L110](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL79-L110))

### Changes to WebSubHub Subscriber:

* Refactored subscription handling by replacing the `buildSubscriptionURL` method with direct parameter handling using `UrlEncodedFormEntity`. This simplifies subscription API calls and improves readability. (`WebSubEventSubscriberImpl.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.javaL113-R128](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L113-R128))
* Adjusted the subscription and unsubscription methods to remove tenant-domain-based topic construction, aligning with the new subscription handling approach. (`WebSubEventSubscriberImpl.java`, [[1]](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L68-R73) [[2]](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L92-R97)

### Dependency and Configuration Updates:

* Added new dependencies for `org.wso2.carbon.identity.topic.management` in the `pom.xml` file to support topic management features. (`pom.xml`, [components/org.wso2.identity.event.websubhub.publisher/pom.xmlR62-R65](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R62-R65))
* Updated package imports in `pom.xml` to include additional Apache HTTP client and WSO2 identity framework packages. (`pom.xml`, [[1]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R120-R133) [[2]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3L134-R144)

### Constants Update:

* Changed the `TOPIC_SEPARATOR` from `"-"` to `"."` and introduced a new constant `REGEX_HTTP_OR_HTTPS_PREFIX` for URL validation in `WebSubHubAdapterConstants`. (`WebSubHubAdapterConstants.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.javaL45-R46](diffhunk://#diff-fb24c2667f4eca69c5aee88c9fd2e68e28f168653932fc78dff932f3f3a9214bL45-R46))
