### PR TITLE
Improve subscription and topic registration

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -49,6 +49,7 @@ public class WebSubHubAdapterConstants {
         public static final String PUBLISH = "publish";
         public static final String HUB_MODE = "hub.mode";
         public static final String HUB_TOPIC = "hub.topic";
+        public static final String HUB_SECRET = "hub.secret";
         public static final String HUB_CALLBACK = "hub.callback";
         public static final String HUB_REASON = "hub.reason";
         public static final String HUB_ACTIVE_SUBS = "hub.active.subscribers";

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -25,12 +25,14 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.common.publisher.EventPublisher;
 import org.wso2.identity.event.websubhub.publisher.config.OutboundAdapterConfigurationProvider;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
 import org.wso2.identity.event.websubhub.publisher.service.WebSubEventPublisherImpl;
 import org.wso2.identity.event.websubhub.publisher.service.WebSubEventSubscriberImpl;
+import org.wso2.identity.event.websubhub.publisher.service.WebSubTopicManagerImpl;
 
 /**
  * WebSubHub Outbound Event Adapter service component.
@@ -58,6 +60,11 @@ public class WebSubHubAdapterServiceComponent {
                 WebSubEventSubscriberImpl subscriberService = new WebSubEventSubscriberImpl();
                 context.getBundleContext().registerService(EventSubscriber.class.getName(),
                         subscriberService, null);
+
+                // Register WebhookTopicManager service
+                WebSubTopicManagerImpl topicManagerService = new WebSubTopicManagerImpl();
+                context.getBundleContext().registerService(TopicManager.class.getName(),
+                        topicManagerService, null);
                 WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
                 WebSubHubAdapterDataHolder.getInstance().setResourceRetriever(new DefaultResourceRetriever());
                 log.debug("Successfully activated the WebSubHub adapter service.");

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -21,10 +21,12 @@ package org.wso2.identity.event.websubhub.publisher.service;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
@@ -108,6 +110,7 @@ public class WebSubTopicManagerImpl implements TopicManager {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
         HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null);
+        httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
 
         WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
         final long requestStartTime = System.currentTimeMillis();

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -289,7 +289,6 @@ public class WebSubHubAdapterUtil {
      */
     public static String constructHubTopic(String channelUri, String eventProfileVersion, String tenantDomain) {
 
-        // Remove protocol (http:// or https://) safely using regex
         String cleanedChannelUri = channelUri.replaceFirst(REGEX_HTTP_OR_HTTPS_PREFIX, "");
         return tenantDomain + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + eventProfileVersion +
                 WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + cleanedChannelUri;

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
     <properties>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.203</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.222</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces enhancements to the WebSubHub event adapter, focusing on improved subscription and unsubscription processes, better topic management, and updates to dependencies. The key changes include adding support for secrets in subscriptions, refining the subscription API, and updating the framework version for compatibility.

### Subscription and Unsubscription Enhancements:
* Modified `subscribe` and `unsubscribe` methods in `WebSubEventSubscriberImpl` to include support for secrets and event profile versions, improving flexibility and security.
* Changed the HTTP response handling in `handleSubscriptionResponse` to expect `202 Accepted` instead of `200 OK`, aligning with updated API behavior.

### Topic Management Improvements:
* Added `Content-Type: application/json` header in `makeTopicMgtAPICall` within `WebSubTopicManagerImpl` to ensure proper API requests for topic management.
* Introduced the `constructHubTopic` utility method in `WebSubHubAdapterUtil` for constructing hub topics based on channel URIs, event profile versions, and tenant domains.

### Dependency Updates:
* Updated `carbon.identity.framework.version` in `pom.xml` from `7.8.203` to `7.8.222` for compatibility with newer features and fixes.