### PR TITLE
Mtls support for subscriber call

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -126,8 +126,8 @@
                             org.apache.http.entity; version="${httpasyncclient.version.range}",
                             org.apache.http.client.config; version="${httpasyncclient.version.range}",
                             org.apache.http.client.entity; version="${httpasyncclient.version.range}",
-                            org.apache.http.conn; version="${httpasyncclient.version.range}",
-                            org.apache.http.conn.ssl; version="${httpasyncclient.version.range}",
+                            org.apache.http.conn.*; version="${httpasyncclient.version.range}",
+                            org.apache.http.conn.ssl.*; version="${httpasyncclient.version.range}",
                             org.apache.http.util; version="${httpasyncclient.version.range}",
                             org.apache.http.ssl; version="${httpasyncclient.version.range}",
                             org.apache.http.message; version="${httpasyncclient.version.range}",
@@ -138,6 +138,10 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            javax.net.ssl,
+                            javax.net,
+                            org.wso2.carbon.identity.core.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.webhook.management.api.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/config/WebSubAdapterConfiguration.java
@@ -34,12 +34,14 @@ public class WebSubAdapterConfiguration {
     private static final String HTTP_CONNECTION_REQUEST_TIMEOUT = "adapter.websubhub.httpConnectionRequestTimeout";
     private static final String DEFAULT_MAX_CONNECTIONS = "adapter.websubhub.defaultMaxConnections";
     private static final String DEFAULT_MAX_CONNECTIONS_PER_ROUTE = "adapter.websubhub.defaultMaxConnectionsPerRoute";
+    private static final String MTLS_ENABLED = "adapter.websubhub.mtlsEnabled";
     private final boolean adapterEnabled;
     private final int httpConnectionTimeout;
     private final int httpReadTimeout;
     private final int httpConnectionRequestTimeout;
     private final int defaultMaxConnections;
     private final int defaultMaxConnectionsPerRoute;
+    private final boolean mtlsEnabled;
     private String webSubHubBaseUrl;
 
 
@@ -64,6 +66,8 @@ public class WebSubAdapterConfiguration {
             }
         }
 
+        this.mtlsEnabled = Boolean.parseBoolean(
+                configurationProvider.getProperty(MTLS_ENABLED));
         this.httpConnectionTimeout = parseIntOrDefault(
                 configurationProvider.getProperty(HTTP_CONNECTION_TIMEOUT),
                 WebSubHubAdapterConstants.Http.DEFAULT_HTTP_CONNECTION_TIMEOUT);
@@ -157,5 +161,15 @@ public class WebSubAdapterConfiguration {
     public int getDefaultMaxConnectionsPerRoute() {
 
         return defaultMaxConnectionsPerRoute;
+    }
+
+    /**
+     * Returns whether mTLS is enabled.
+     *
+     * @return true if mTLS is enabled, false otherwise.
+     */
+    public boolean isMtlsEnabled() {
+
+        return mtlsEnabled;
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -67,6 +67,7 @@ public class WebSubHubAdapterConstants {
         public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE = 2;
         public static final String SUBSCRIBE = "subscribe";
         public static final String UNSUBSCRIBE = "unsubscribe";
+        public static final String WEBSUBHUB_KEYSTORE_NAME = "websubhub-dev-client.p12";
 
         private Http() {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -25,6 +25,10 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.common.publisher.EventPublisher;
@@ -74,6 +78,23 @@ public class WebSubHubAdapterServiceComponent {
         } catch (Throwable e) {
             log.error("Can not activate the WebSubHub adapter service: " + e.getMessage(), e);
         }
+    }
+
+    @Reference(
+            name = "identity.core.init.event.service",
+            service = IdentityCoreInitializedEvent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityCoreInitializedEventService"
+    )
+    protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
+    }
+
+    protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
     }
 
     @Deactivate

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -123,7 +123,8 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
             final long requestStartTime = System.currentTimeMillis();
 
-            try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.execute(httpPost)) {
+            try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.executeSubscriberRequest(
+                    httpPost)) {
                 int responseCode = response.getStatusLine().getStatusCode();
                 if (responseCode >= 500 && attempt < MAX_RETRIES) {
                     attempt++;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -100,14 +100,14 @@ public class WebSubEventSubscriberImplTest {
 
         HttpPost mockHttpPost = mock(HttpPost.class);
         when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
-        when(mockClientManager.execute(any())).thenReturn(mockHttpResponse);
+        when(mockClientManager.executeSubscriberRequest(any())).thenReturn(mockHttpResponse);
         StatusLine mockStatusLine = mock(StatusLine.class);
         when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
         when(mockStatusLine.getStatusCode()).thenReturn(202); // SC_ACCEPTED
 
         subscriberService.subscribe(channels, eventProfileVersion, callbackUrl, secret, tenantDomain);
 
-        verify(mockClientManager, times(2)).execute(any());
+        verify(mockClientManager, times(2)).executeSubscriberRequest(any());
     }
 
     @Test
@@ -120,14 +120,14 @@ public class WebSubEventSubscriberImplTest {
 
         HttpPost mockHttpPost = mock(HttpPost.class);
         when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
-        when(mockClientManager.execute(any())).thenReturn(mockHttpResponse);
+        when(mockClientManager.executeSubscriberRequest(any())).thenReturn(mockHttpResponse);
         StatusLine mockStatusLine = mock(StatusLine.class);
         when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
         when(mockStatusLine.getStatusCode()).thenReturn(202); // SC_ACCEPTED
 
         subscriberService.unsubscribe(channels, eventProfileVersion, callbackUrl, tenantDomain);
 
-        verify(mockClientManager, times(2)).execute(any());
+        verify(mockClientManager, times(2)).executeSubscriberRequest(any());
     }
 
     @Test(expectedExceptions = WebhookMgtException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         </plugins>
     </build>
     <properties>
-        <carbon.kernel.version>4.9.10</carbon.kernel.version>
+        <carbon.kernel.version>4.10.53</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.identity.framework.version>7.8.222</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces support for mTLS (mutual TLS) in the WebSubHub adapter, along with other enhancements and updates to dependencies. The key changes include adding mTLS configuration and client initialization, updating HTTP client handling, and modifying related tests to accommodate the new functionality.

### mTLS Support:

* Added a new configuration property `adapter.websubhub.mtlsEnabled` and corresponding field `mtlsEnabled` in `WebSubAdapterConfiguration` to enable or disable mTLS. (`WebSubAdapterConfiguration.java`, [[1]](diffhunk://#diff-e9c2cb14db77e6545dd6e9ba953850e0fdd4336a383e32f9f666859fd7cce0d5R37-R44) [[2]](diffhunk://#diff-e9c2cb14db77e6545dd6e9ba953850e0fdd4336a383e32f9f666859fd7cce0d5R69-R70) [[3]](diffhunk://#diff-e9c2cb14db77e6545dd6e9ba953850e0fdd4336a383e32f9f666859fd7cce0d5R165-R174)
* Implemented `getMTLSClient()` in `ClientManager` to initialize an HTTP client with mTLS support using a custom keystore and truststore. (`ClientManager.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.javaR116-R183](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eR116-R183))
* Added `getEffectiveHttpClient()` to dynamically choose between the default HTTP client and the mTLS-enabled client based on configuration. (`ClientManager.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.javaR198-R211](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eR198-R211))

### HTTP Client Enhancements:

* Introduced `executeSubscriberRequest()` in `ClientManager` to handle HTTP POST requests using the effective HTTP client. (`ClientManager.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.javaR328-R340](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eR328-R340))
* Updated `WebSubEventSubscriberImpl` to use `executeSubscriberRequest()` for subscription-related API calls. (`WebSubEventSubscriberImpl.java`, [components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.javaL126-R127](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L126-R127))

### Test Updates:

* Modified test cases in `WebSubEventSubscriberImplTest` to mock and verify calls to `executeSubscriberRequest()` instead of `execute()`. (`WebSubEventSubscriberImplTest.java`, [[1]](diffhunk://#diff-74f2456dbee40cd9ebfce0b8dbf3692e818bfc76a6fe0c98aa353ba84d966adeL103-R110) [[2]](diffhunk://#diff-74f2456dbee40cd9ebfce0b8dbf3692e818bfc76a6fe0c98aa353ba84d966adeL123-R130)

### Dependency and Configuration Updates:

* Updated the Carbon Kernel version to `4.10.53` in the root `pom.xml`. (`pom.xml`, [pom.xmlL381-R381](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L381-R381))
* Updated package imports in `pom.xml` files to include new dependencies required for mTLS support. (`org.wso2.identity.event.websubhub.publisher/pom.xml`, [[1]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3L129-R130) [[2]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R142-R145)

### Service Component Changes:

* Added a reference to `IdentityCoreInitializedEvent` in `WebSubHubAdapterServiceComponent` to ensure the component waits for the identity core to initialize before activation. (`WebSubHubAdapterServiceComponent.java`, [[1]](diffhunk://#diff-4e0f8e9093345247632daacc1f9e8643b9271ddd6ba8f2b3f049344ae3361f21R28-R31) [[2]](diffhunk://#diff-4e0f8e9093345247632daacc1f9e8643b9271ddd6ba8f2b3f049344ae3361f21R83-R99)
