### PR TITLE
Update the file type to jks

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -69,7 +69,7 @@ public class WebSubHubAdapterConstants {
         public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE = 2;
         public static final String SUBSCRIBE = "subscribe";
         public static final String UNSUBSCRIBE = "unsubscribe";
-        public static final String WEBSUBHUB_KEYSTORE_NAME = "websubhubKeyStore.p12";
+        public static final String WEBSUBHUB_KEYSTORE_NAME = "websubhubKeyStore.jks";
 
         private Http() {
 


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a small change to the `WebSubHubAdapterConstants.java` file, updating the keystore file format used by the WebSubHub component.

* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java`](diffhunk://#diff-fb24c2667f4eca69c5aee88c9fd2e68e28f168653932fc78dff932f3f3a9214bL72-R72): Changed the `WEBSUBHUB_KEYSTORE_NAME` constant from `websubhubKeyStore.p12` to `websubhubKeyStore.jks`.
