### PR TITLE
Manage subscription state and improved topic mgt request call

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -69,7 +69,7 @@ public class WebSubHubAdapterConstants {
         public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE = 2;
         public static final String SUBSCRIBE = "subscribe";
         public static final String UNSUBSCRIBE = "unsubscribe";
-        public static final String WEBSUBHUB_KEYSTORE_NAME = "websubhub-dev-client.p12";
+        public static final String WEBSUBHUB_KEYSTORE_NAME = "websubhub-dev-client.jks";
 
         private Http() {
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -27,7 +27,8 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
-import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
+import org.wso2.carbon.identity.webhook.management.api.model.subscription.Subscription;
+import org.wso2.carbon.identity.webhook.management.api.model.subscription.SubscriptionStatus;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
@@ -54,14 +55,11 @@ import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterU
 
 /**
  * OSGi service for managing WebSubHub subscriptions.
- * TODO: Introduce a proper exception handler for the subscriber with explicit error codes.
  * TODO: Add diagnostic logs
  */
 public class WebSubEventSubscriberImpl implements EventSubscriber {
 
     private static final Log log = LogFactory.getLog(WebSubEventSubscriberImpl.class);
-    private static final int MAX_RETRIES = 2;
-    private static final long RETRY_DELAY_MS = 400;
 
     @Override
     public String getName() {
@@ -70,35 +68,64 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
     }
 
     @Override
-    public void subscribe(List<String> channels, String eventProfileVersion, String endpoint, String secret,
-                          String tenantDomain) throws WebhookMgtException {
+    public List<Subscription> subscribe(List<String> channels, String eventProfileVersion, String endpoint,
+                                        String secret, String tenantDomain) {
 
+        List<Subscription> subscriptions = new ArrayList<>();
         for (String channel : channels) {
             try {
                 makeSubscriptionAPICall(constructHubTopic(channel, eventProfileVersion, tenantDomain),
                         getWebSubBaseURL(), WebSubHubAdapterConstants.Http.SUBSCRIBE, endpoint, secret);
                 log.debug("WebSubHub subscription successful for channel: " + channel +
                         " with endpoint: " + endpoint + " in tenant: " + tenantDomain);
+
+                Subscription subscription = Subscription.builder()
+                        .channelUri(channel)
+                        .status(SubscriptionStatus.SUBSCRIPTION_ACCEPTED)
+                        .build();
+                subscriptions.add(subscription);
             } catch (WebSubAdapterException e) {
-                throw new WebhookMgtException(e.getMessage(), e);
+                log.debug("Error subscribing to channel: " + channel + " with endpoint: " + endpoint +
+                        " in tenant: " + tenantDomain + ". Error: " + e.getMessage(), e);
+                Subscription subscription = Subscription.builder()
+                        .channelUri(channel)
+                        .status(SubscriptionStatus.SUBSCRIPTION_ERROR)
+                        .build();
+                subscriptions.add(subscription);
             }
         }
+        return subscriptions;
     }
 
     @Override
-    public void unsubscribe(List<String> channels, String eventProfileVersion, String endpoint,
-                            String tenantDomain) throws WebhookMgtException {
+    public List<Subscription> unsubscribe(List<String> channels, String eventProfileVersion, String endpoint,
+                                          String tenantDomain) {
 
+        List<Subscription> subscriptions = new ArrayList<>();
         for (String channel : channels) {
             try {
                 makeSubscriptionAPICall(constructHubTopic(channel, eventProfileVersion, tenantDomain),
                         getWebSubBaseURL(), WebSubHubAdapterConstants.Http.UNSUBSCRIBE, endpoint, null);
                 log.debug("WebSubHub unsubscription successful for channel: " + channel +
                         " with endpoint: " + endpoint + " in tenant: " + tenantDomain);
+
+                Subscription subscription = Subscription.builder()
+                        .channelUri(channel)
+                        .status(SubscriptionStatus.UNSUBSCRIPTION_ACCEPTED)
+                        .build();
+                subscriptions.add(subscription);
             } catch (WebSubAdapterException e) {
-                throw new WebhookMgtException(e.getMessage(), e);
+                log.debug("Error unsubscribing from channel: " + channel + " with endpoint: " + endpoint +
+                        " in tenant: " + tenantDomain + ". Error: " + e.getMessage(), e);
+
+                Subscription subscription = Subscription.builder()
+                        .channelUri(channel)
+                        .status(SubscriptionStatus.UNSUBSCRIPTION_ERROR)
+                        .build();
+                subscriptions.add(subscription);
             }
         }
+        return subscriptions;
     }
 
     private void makeSubscriptionAPICall(String topic, String webSubHubBaseUrl, String operation, String callbackUrl,
@@ -106,54 +133,27 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
 
-        int attempt = 0;
-        while (true) {
-            HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null);
-            httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+        HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null);
+        httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
 
-            List<BasicNameValuePair> params = new ArrayList<>();
-            params.add(new BasicNameValuePair(HUB_CALLBACK, callbackUrl));
-            params.add(new BasicNameValuePair(HUB_MODE, operation));
-            params.add(new BasicNameValuePair(HUB_TOPIC, topic));
-            if (secret != null) {
-                params.add(new BasicNameValuePair(HUB_SECRET, secret));
-            }
-            httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair(HUB_CALLBACK, callbackUrl));
+        params.add(new BasicNameValuePair(HUB_MODE, operation));
+        params.add(new BasicNameValuePair(HUB_TOPIC, topic));
+        if (secret != null) {
+            params.add(new BasicNameValuePair(HUB_SECRET, secret));
+        }
+        httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
-            final long requestStartTime = System.currentTimeMillis();
+        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);
+        final long requestStartTime = System.currentTimeMillis();
 
-            try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.executeSubscriberRequest(
-                    httpPost)) {
-                int responseCode = response.getStatusLine().getStatusCode();
-                if (responseCode >= 500 && attempt < MAX_RETRIES) {
-                    attempt++;
-                    log.debug("Retrying subscription API call, attempt " + attempt + " for topic: " + topic);
-                    try {
-                        Thread.sleep(RETRY_DELAY_MS);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        throw handleServerException(ERROR_SUBSCRIBING_TO_TOPIC, ie);
-                    }
-                    continue;
-                }
-                handleSubscriptionResponse(response, httpPost, topic, operation, requestStartTime);
-                break;
-            } catch (IOException | WebSubAdapterException e) {
-                log.debug("Error subscribing to topic: " + topic + ". Error: " + e.getMessage(), e);
-                if (attempt < MAX_RETRIES) {
-                    attempt++;
-                    log.debug("Retrying subscription API call, attempt " + attempt + " for topic: " + topic);
-                    try {
-                        Thread.sleep(RETRY_DELAY_MS);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        throw handleServerException(ERROR_SUBSCRIBING_TO_TOPIC, ie);
-                    }
-                    continue;
-                }
-                throw handleServerException(ERROR_SUBSCRIBING_TO_TOPIC, e);
-            }
+        try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.executeSubscriberRequest(
+                httpPost)) {
+            handleSubscriptionResponse(response, httpPost, topic, operation, requestStartTime);
+        } catch (IOException | WebSubAdapterException e) {
+            log.debug("Error subscribing to topic: " + topic + ". Error: " + e.getMessage(), e);
+            throw handleServerException(ERROR_SUBSCRIBING_TO_TOPIC, e);
         }
     }
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -29,9 +29,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
-import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.api.model.Subscription;
 import org.wso2.carbon.identity.webhook.management.api.model.SubscriptionStatus;
+import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
@@ -101,7 +101,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
                 }
             }
         } catch (WebhookMgtException e) {
-            log.debug("Error retrieving events from webhook: " + webhook.getUuid() +
+            log.warn("Error retrieving events from webhook: " + webhook.getId() +
                     " in tenant: " + tenantDomain + ". Error: " + e.getMessage(), e);
         }
         return subscriptions;
@@ -140,7 +140,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
                 }
             }
         } catch (WebhookMgtException e) {
-            log.debug("Error retrieving events from webhook: " + webhook.getUuid() +
+            log.warn("Error retrieving events from webhook: " + webhook.getId() +
                     " in tenant: " + IdentityTenantUtil.getTenantDomain(tenantId) +
                     ". Error: " + e.getMessage(), e);
         }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -63,7 +63,6 @@ import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterU
 public class WebSubEventSubscriberImpl implements EventSubscriber {
 
     private static final Log log = LogFactory.getLog(WebSubEventSubscriberImpl.class);
-    private static final String eventProfileVersion = "v1";
 
     @Override
     public String getName() {
@@ -72,17 +71,17 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
     }
 
     @Override
-    public List<Subscription> subscribe(Webhook webhook) {
+    public List<Subscription> subscribe(Webhook webhook, int tenantId) {
 
         List<Subscription> subscriptions = new ArrayList<>();
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(webhook.getTenantId());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         try {
             for (Subscription eventSubscription : webhook.getEventsSubscribed()) {
                 try {
                     makeSubscriptionAPICall(
-                            constructHubTopic(eventSubscription.getChannelUri(), eventProfileVersion, tenantDomain),
-                            getWebSubBaseURL(), WebSubHubAdapterConstants.Http.SUBSCRIBE, webhook.getEndpoint(),
-                            webhook.getSecret());
+                            constructHubTopic(eventSubscription.getChannelUri(), webhook.getEventProfileVersion(),
+                                    tenantDomain), getWebSubBaseURL(), WebSubHubAdapterConstants.Http.SUBSCRIBE,
+                            webhook.getEndpoint(), webhook.getSecret());
                     log.debug("WebSubHub subscription successful for channel: " + eventSubscription.getChannelUri() +
                             " with endpoint: " + webhook.getEndpoint() + " in tenant: " + tenantDomain);
 
@@ -109,17 +108,17 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
     }
 
     @Override
-    public List<Subscription> unsubscribe(Webhook webhook) {
+    public List<Subscription> unsubscribe(Webhook webhook, int tenantId) {
 
         List<Subscription> subscriptions = new ArrayList<>();
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(webhook.getTenantId());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         try {
             for (Subscription eventSubscription : webhook.getEventsSubscribed()) {
                 try {
                     makeSubscriptionAPICall(
-                            constructHubTopic(eventSubscription.getChannelUri(), eventProfileVersion, tenantDomain),
-                            getWebSubBaseURL(), WebSubHubAdapterConstants.Http.UNSUBSCRIBE, webhook.getEndpoint(),
-                            null);
+                            constructHubTopic(eventSubscription.getChannelUri(), webhook.getEventProfileVersion(),
+                                    tenantDomain), getWebSubBaseURL(), WebSubHubAdapterConstants.Http.UNSUBSCRIBE,
+                            webhook.getEndpoint(), null);
                     log.debug("WebSubHub unsubscription successful for channel: " + eventSubscription.getChannelUri() +
                             " with endpoint: " + webhook.getEndpoint() + " in tenant: " + tenantDomain);
 
@@ -142,7 +141,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
             }
         } catch (WebhookMgtException e) {
             log.debug("Error retrieving events from webhook: " + webhook.getUuid() +
-                    " in tenant: " + IdentityTenantUtil.getTenantDomain(webhook.getTenantId()) +
+                    " in tenant: " + IdentityTenantUtil.getTenantDomain(tenantId) +
                     ". Error: " + e.getMessage(), e);
         }
         return subscriptions;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -171,8 +171,10 @@ public class WebSubTopicManagerImpl implements TopicManager {
                     if (entity != null) {
                         responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
                     }
-                    log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
-                            topic, operation, responseString));
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
+                                topic, operation, responseString));
+                    }
                 } else {
                     WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
                             WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -27,6 +27,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
@@ -38,9 +39,13 @@ import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_DEREGISTERING_HUB_TOPIC;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.DEREGISTER;
@@ -48,14 +53,12 @@ import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdap
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_ACTIVE_SUBS;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_REASON;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.REGISTER;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.RESPONSE_FOR_SUCCESSFUL_OPERATION;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleClientException;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleErrorResponse;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleFailedOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleServerException;
-import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleSuccessfulOperation;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleTopicMgtException;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.parseEventHubResponse;
 
@@ -113,7 +116,7 @@ public class WebSubTopicManagerImpl implements TopicManager {
         }
     }
 
-    private void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
+    public static void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
             throws WebSubAdapterException {
 
         String topicMgtUrl = buildURL(topic, webSubHubBaseUrl, operation);
@@ -128,24 +131,82 @@ public class WebSubTopicManagerImpl implements TopicManager {
             final long requestStartTime = System.currentTimeMillis();
 
             try (CloseableHttpResponse response = (CloseableHttpResponse) clientManager.execute(httpPost)) {
-                int responseCode = response.getStatusLine().getStatusCode();
-                if (responseCode >= 500 && attempt < MAX_RETRIES) {
+
+                StatusLine statusLine = response.getStatusLine();
+                int responseCode = statusLine.getStatusCode();
+                String responsePhrase = statusLine.getReasonPhrase();
+
+                if (responseCode >= 500 && responseCode < 600 && attempt < MAX_RETRIES) {
                     attempt++;
-                    log.info("Retrying topic management API call, attempt " + attempt + " for topic: " + topic);
-                    try {
-                        Thread.sleep(RETRY_DELAY_MS);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        throw handleServerException(ERROR_REGISTERING_HUB_TOPIC, ie, topic, tenantDomain);
-                    }
+                    log.debug("Retrying topic management API call, attempt " + attempt + " for topic: " + topic);
+                    Thread.sleep(RETRY_DELAY_MS);
                     continue;
                 }
-                handleTopicMgtResponse(response, httpPost, topic, operation, requestStartTime);
-                break; // Success or handled error
-            } catch (IOException | WebSubAdapterException e) {
+
+                if (responseCode == HttpStatus.SC_OK) {
+                    HttpEntity entity = response.getEntity();
+                    WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                            WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
+                            String.valueOf(responseCode), responsePhrase);
+                    if (entity != null) {
+                        String responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                        if (RESPONSE_FOR_SUCCESSFUL_OPERATION.equals(responseString)) {
+                            log.debug("Success WebSub Hub operation: " + operation + ", topic: " + topic);
+                        } else {
+                            throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null, topic,
+                                    operation, responseString);
+                        }
+                    } else {
+                        String message =
+                                String.format(ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getDescription(), topic, operation);
+                        throw new WebSubAdapterServerException(message, ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getCode());
+                    }
+                } else if ((responseCode == HttpStatus.SC_CONFLICT && operation.equals(REGISTER)) ||
+                        (responseCode == HttpStatus.SC_NOT_FOUND && operation.equals(DEREGISTER))) {
+                    HttpEntity entity = response.getEntity();
+                    String responseString = "";
+                    WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                            WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
+                            String.valueOf(responseCode), responsePhrase);
+                    if (entity != null) {
+                        responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                    }
+                    log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
+                            topic, operation, responseString));
+                } else {
+                    WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
+                            WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
+                            String.valueOf(responseCode), responsePhrase);
+                    if (responseCode == HttpStatus.SC_FORBIDDEN) {
+                        Map<String, String> hubResponse = parseEventHubResponse(response);
+                        if (!hubResponse.isEmpty() && hubResponse.containsKey(HUB_REASON)) {
+                            String errorMsg = String.format(ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, topic);
+                            if (errorMsg.equals(hubResponse.get(HUB_REASON))) {
+                                log.error(String.format(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS.getDescription(),
+                                        topic, hubResponse.get(HUB_ACTIVE_SUBS)));
+                                throw handleClientException(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS, topic,
+                                        hubResponse.get(HUB_ACTIVE_SUBS));
+                            }
+                        }
+                    }
+                    HttpEntity entity = response.getEntity();
+                    String responseString = "";
+                    if (entity != null) {
+                        responseString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+                    }
+                    String message = String.format(ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getDescription(),
+                            topic, operation, responseString);
+                    log.error(message + ", Response code:" + responseCode);
+                    throw new WebSubAdapterServerException(message, ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB.getCode());
+                }
+
+                break;
+            } catch (IOException e) {
+
                 if (attempt < MAX_RETRIES) {
                     attempt++;
-                    log.info("Retrying topic management API call, attempt " + attempt + " for topic: " + topic);
+                    log.debug("Retrying topic management API call due to network error, attempt " + attempt +
+                            " for topic: " + topic);
                     try {
                         Thread.sleep(RETRY_DELAY_MS);
                     } catch (InterruptedException ie) {
@@ -155,54 +216,9 @@ public class WebSubTopicManagerImpl implements TopicManager {
                     continue;
                 }
                 throw handleServerException(ERROR_REGISTERING_HUB_TOPIC, e, topic, tenantDomain);
-            }
-        }
-    }
-
-    private void handleTopicMgtResponse(CloseableHttpResponse response, HttpPost httpPost,
-                                        String topic, String operation, long requestStartTime)
-            throws IOException, WebSubAdapterException {
-
-        StatusLine statusLine = response.getStatusLine();
-        int responseCode = statusLine.getStatusCode();
-        String responsePhrase = statusLine.getReasonPhrase();
-
-        if (responseCode == HttpStatus.SC_OK) {
-            HttpEntity entity = response.getEntity();
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            handleSuccessfulOperation(entity, topic, operation);
-        } else if ((responseCode == HttpStatus.SC_CONFLICT && operation.equals(REGISTER)) ||
-                (responseCode == HttpStatus.SC_NOT_FOUND && operation.equals(DEREGISTER))) {
-            HttpEntity entity = response.getEntity();
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            handleErrorResponse(entity, topic, operation);
-        } else {
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(httpPost, requestStartTime,
-                    WebSubHubCorrelationLogUtils.RequestStatus.CANCELLED.getStatus(),
-                    String.valueOf(responseCode), responsePhrase);
-            if (responseCode == HttpStatus.SC_FORBIDDEN) {
-                handleForbiddenResponse(response, topic);
-            }
-            HttpEntity entity = response.getEntity();
-            handleFailedOperation(entity, topic, operation, responseCode);
-        }
-    }
-
-    private static void handleForbiddenResponse(CloseableHttpResponse response, String topic) throws IOException,
-            WebSubAdapterException {
-
-        Map<String, String> hubResponse = parseEventHubResponse(response);
-        if (!hubResponse.isEmpty() && hubResponse.containsKey(HUB_REASON)) {
-            String errorMsg = String.format(ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, topic);
-            if (errorMsg.equals(hubResponse.get(HUB_REASON))) {
-                log.debug(String.format(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS.getDescription(),
-                        topic, hubResponse.get(HUB_ACTIVE_SUBS)));
-                throw handleClientException(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS, topic,
-                        hubResponse.get(HUB_ACTIVE_SUBS));
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw handleServerException(ERROR_REGISTERING_HUB_TOPIC, ie, topic, tenantDomain);
             }
         }
     }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -116,7 +116,7 @@ public class WebSubTopicManagerImpl implements TopicManager {
         }
     }
 
-    public static void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
+    private void makeTopicMgtAPICall(String topic, String webSubHubBaseUrl, String operation, String tenantDomain)
             throws WebSubAdapterException {
 
         String topicMgtUrl = buildURL(topic, webSubHubBaseUrl, operation);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
@@ -158,25 +158,17 @@ public class WebSubTopicManagerImplTest {
     @Test
     public void testConstructTopic() throws TopicManagementException {
 
-        String topic = webSubTopicManager.constructTopic("channel-uri", "1.0",
-                "carbon.super");
-
+        String topic = webSubTopicManager.constructTopic("channel-uri", "1.0", "carbon.super");
         assertEquals(topic, "carbon.super.1.0.channel-uri");
-
         mockedStaticUtil.verify(() ->
-                WebSubHubAdapterUtil.constructHubTopic("channel-uri", "1.0",
-                        "carbon.super"));
+                WebSubHubAdapterUtil.constructHubTopic("channel-uri", "1.0", "carbon.super"));
     }
 
     @Test
     public void testRegisterTopicSuccess() throws TopicManagementException, WebSubAdapterException, IOException {
-        // Setup success response
+
         when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
-        // Execute the method
         webSubTopicManager.registerTopic("test-topic", "carbon.super");
-
-        // Verify interactions
         verify(mockClientManager).createHttpPost(anyString(), any());
         verify(mockClientManager).execute(any(HttpPost.class));
     }
@@ -185,16 +177,12 @@ public class WebSubTopicManagerImplTest {
     public void testDeregisterTopicSuccess() throws TopicManagementException, WebSubAdapterException, IOException {
 
         when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
         webSubTopicManager.deregisterTopic("test-topic", "carbon.super");
-
         verify(mockClientManager).createHttpPost(anyString(), any());
         verify(mockClientManager).execute(any(HttpPost.class));
-
-        mockedStaticCorrelationLogUtils.verify(() ->
-                WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(any(HttpPost.class)));
-        mockedStaticUtil.verify(() ->
-                WebSubHubAdapterUtil.handleSuccessfulOperation(any(), eq("test-topic"), eq("deregister")));
+        mockedStaticUtil.verify(() -> WebSubHubAdapterUtil.getWebSubBaseURL());
+        mockedStaticUtil.verify(
+                () -> WebSubHubAdapterUtil.buildURL("test-topic", "https://hub.example.com", "deregister"));
     }
 
     @Test(expectedExceptions = TopicManagementException.class)
@@ -226,7 +214,6 @@ public class WebSubTopicManagerImplTest {
                         ))
                 .thenReturn(new TopicManagementException("Error", "Description", "CODE"));
 
-        // Execute the method - should throw exception
         webSubTopicManager.registerTopic("test-topic", "carbon.super");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
     <properties>
         <carbon.kernel.version>4.10.53</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.version>7.8.233</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.255</carbon.identity.framework.version>
         <identity.outbound.adapter.version.range>[1.0.0, 2.0.0)</identity.outbound.adapter.version.range>
         <httpclient.httpcomponents.wso2.version>4.5.13.wso2v1</httpclient.httpcomponents.wso2.version>
         <httpclient.httpcomponents.wso2.version.range>[4.5.0, 5.0.0)</httpclient.httpcomponents.wso2.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces several changes to improve the subscription and topic management functionalities within the WebSubHub publisher service. The key updates include replacing exception-based error handling with detailed subscription status tracking, refactoring retry logic for API calls, and enhancing response validation to ensure robustness.

### Subscription Management Enhancements:
* Updated `subscribe` and `unsubscribe` methods in `WebSubEventSubscriberImpl` to return a list of `Subscription` objects, capturing detailed subscription statuses (`SUBSCRIPTION_ACCEPTED`, `SUBSCRIPTION_ERROR`, etc.) instead of throwing exceptions.
* Improved error logging within the subscription methods to provide more context about failures.

### Retry Logic Improvements:
* Removed hardcoded retry logic (`MAX_RETRIES` and `RETRY_DELAY_MS`) from `makeSubscriptionAPICall` and `makeTopicMgtAPICall` methods, simplifying the retry mechanism for API calls. [[1]](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L128-L158) [[2]](diffhunk://#diff-8ae609453d8a77dcc3b8c3d51e6b76b83df71542e6185317554f46ed1351bf07L131-R224)

### Response Handling Enhancements:
* Enhanced response validation in `makeTopicMgtAPICall` to handle empty or invalid responses more gracefully, throwing specific exceptions with detailed messages when necessary.
* Added support for parsing and logging detailed backend error responses from WebSubHub during topic management operations.

### Code Refactoring:
* Changed the visibility of `makeTopicMgtAPICall` from private to public to facilitate broader usage within the codebase.
* Removed unused imports and redundant methods to streamline the code in both `WebSubEventSubscriberImpl` and `WebSubTopicManagerImpl`. [[1]](diffhunk://#diff-d21e21e2f1ce7e2a2f869f9e049582df2c65d2bf7624fa135d65a894fd6e74c1L30-R31) [[2]](diffhunk://#diff-8ae609453d8a77dcc3b8c3d51e6b76b83df71542e6185317554f46ed1351bf07R42-L58)

These changes collectively improve the reliability, maintainability, and clarity of the WebSubHub publisher service.