### PR TITLE
updated mtls support

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -216,7 +216,7 @@ public class ClientManager {
                 .isMtlsEnabled()) {
             return mtlsHttpClient;
         }
-        return getHttpClient();
+        return mtlsHttpClient;
     }
 
     private RequestConfig createRequestConfig() {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request includes a minor but impactful change to the `ClientManager` class in the `WebSubHub` publisher module. The change ensures that `mtlsHttpClient` is returned unconditionally from the `getEffectiveHttpClient()` method, removing the fallback to `getHttpClient()`.

Key change:

* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java`](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eL219-R219): Updated the `getEffectiveHttpClient()` method to always return `mtlsHttpClient`, ensuring consistent use of mutual TLS for HTTP client operations.