### PR TITLE
default make mtls client

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -116,10 +116,7 @@ public class ClientManager {
                     syncConnectionManager.getDefaultMaxPerRoute());
 
             // Initialize MTLS HttpClient
-            if (WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
-                    .isMtlsEnabled()) {
-                mtlsHttpClient = getMTLSClient();
-            }
+            mtlsHttpClient = getMTLSClient();
         } catch (IOException e) {
             throw WebSubHubAdapterUtil.handleServerException(
                     WebSubHubAdapterConstants.ErrorMessages.ERROR_GETTING_ASYNC_CLIENT, e);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request modifies the initialization logic for the MTLS (Mutual TLS) HTTP client in the `ClientManager` class to simplify the code and remove unnecessary conditional checks.

Code simplification:

* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java`](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eL119-L122): Removed the conditional check for `isMtlsEnabled()` during MTLS HTTP client initialization, ensuring the client is always initialized without checking the configuration.
