### PR TITLE
fix bug

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -116,7 +116,6 @@ public class ClientManager {
                     syncConnectionManager.getDefaultMaxPerRoute());
 
             // Initialize MTLS HttpClient
-            mtlsHttpClient = getMTLSClient();
         } catch (IOException e) {
             throw WebSubHubAdapterUtil.handleServerException(
                     WebSubHubAdapterConstants.ErrorMessages.ERROR_GETTING_ASYNC_CLIENT, e);
@@ -207,8 +206,9 @@ public class ClientManager {
      *
      * @return CloseableHttpClient instance.
      */
-    public CloseableHttpClient getEffectiveHttpClient() {
+    public CloseableHttpClient getEffectiveHttpClient() throws WebSubAdapterException {
 
+        mtlsHttpClient = getMTLSClient();
         if (WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
                 .isMtlsEnabled()) {
             return mtlsHttpClient;


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request modifies the `ClientManager` class in the `WebSubHub` publisher component to improve the handling of MTLS (Mutual TLS) HTTP client initialization. The changes ensure that the MTLS client is properly initialized when required and streamline the method responsible for retrieving the effective HTTP client.

### Changes to MTLS HTTP client handling:

* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java`](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eL119): Removed redundant initialization of `mtlsHttpClient` in the constructor, as it is now handled dynamically in the `getEffectiveHttpClient` method.
* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java`](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eL210-R211): Updated the `getEffectiveHttpClient` method to initialize `mtlsHttpClient` dynamically and added exception handling for better error management when MTLS is enabled.