### PR TITLE
Revert fixes

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -116,6 +116,10 @@ public class ClientManager {
                     syncConnectionManager.getDefaultMaxPerRoute());
 
             // Initialize MTLS HttpClient
+            if (WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
+                    .isMtlsEnabled()) {
+                mtlsHttpClient = getMTLSClient();
+            }
         } catch (IOException e) {
             throw WebSubHubAdapterUtil.handleServerException(
                     WebSubHubAdapterConstants.ErrorMessages.ERROR_GETTING_ASYNC_CLIENT, e);
@@ -206,14 +210,13 @@ public class ClientManager {
      *
      * @return CloseableHttpClient instance.
      */
-    public CloseableHttpClient getEffectiveHttpClient() throws WebSubAdapterException {
+    public CloseableHttpClient getEffectiveHttpClient() {
 
-        mtlsHttpClient = getMTLSClient();
         if (WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
                 .isMtlsEnabled()) {
             return mtlsHttpClient;
         }
-        return mtlsHttpClient;
+        return getHttpClient();
     }
 
     private RequestConfig createRequestConfig() {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces changes to the `ClientManager` class in the WebSubHub publisher component to improve the handling of mutual TLS (mTLS) configuration. The most notable updates include conditional initialization of the mTLS HTTP client and a simplification of the `getEffectiveHttpClient` method.

### Improvements to mTLS handling:

* `components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java`:
  - Added conditional initialization of the mTLS HTTP client (`mtlsHttpClient`) based on the adapter configuration in the constructor. This ensures the client is only initialized when mTLS is enabled.
  - Simplified the `getEffectiveHttpClient` method by removing redundant code and ensuring it returns the correct HTTP client based on the mTLS configuration.
