### PR TITLE
Lowercase the event profile name

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -335,7 +335,7 @@ public class WebSubHubAdapterUtil {
         return tenantDomain + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + getOrganizationId(tenantDomain) +
                 WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR +
                 WebSubHubAdapterConstants.SCHEMA + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR +
-                eventProfileName + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR +
+                eventProfileName.toLowerCase() + WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR +
                 eventProfileVersion +
                 WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + WebSubHubAdapterConstants.EVENT +
                 WebSubHubAdapterConstants.Http.TOPIC_SEPARATOR + event;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -103,6 +103,7 @@ public class WebSubEventPublisherImplTest {
             // Mock inputs
             EventContext eventContext = EventContext.builder()
                     .tenantDomain("test-tenant")
+                    .eventProfileName("WSO2")
                     .eventUri("test-uri")
                     .build();
             SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request includes a minor but important change to the `constructHubTopic` method in `WebSubHubAdapterUtil.java`. The change ensures that the `eventProfileName` is converted to lowercase when constructing the hub topic string.

* [`components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java`](diffhunk://#diff-2fe3757037cab70102eb2fef7eba5f87b96039b7b16e4bac4b535982eee19dcdL338-R338): Modified the `constructHubTopic` method to use `eventProfileName.toLowerCase()` for consistent topic naming and to avoid potential case-sensitivity issues.
