### PR TITLE
[IS 7.2.0 POST ALPHA][skip ci] Update `next` branch versions

### DIFF
--- a/components/org.wso2.identity.event.http.publisher/pom.xml
+++ b/components/org.wso2.identity.event.http.publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-event-publishers</artifactId>
         <groupId>org.wso2.identity.event.publishers</groupId>
-        <version>1.0.31</version>
+        <version>1.0.31-next-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-event-publishers</artifactId>
         <groupId>org.wso2.identity.event.publishers</groupId>
-        <version>1.0.31</version>
+        <version>1.0.31-next-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/http-event-publisher/org.wso2.identity.event.http.publisher.server.feature/pom.xml
+++ b/features/http-event-publisher/org.wso2.identity.event.http.publisher.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.identity.event.publishers</groupId>
         <artifactId>http-event-publisher-feature</artifactId>
-        <version>1.0.31</version>
+        <version>1.0.31-next-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/http-event-publisher/pom.xml
+++ b/features/http-event-publisher/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.identity.event.publishers</groupId>
         <artifactId>identity-event-publishers</artifactId>
-        <version>1.0.31</version>
+        <version>1.0.31-next-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.wso2.identity.event.publishers</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.31</version>
+    <version>1.0.31-next-SNAPSHOT</version>
     <artifactId>identity-event-publishers</artifactId>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
### Purpose

Add the `next` suffix to the POM versions.

### Related Issues
- https://github.com/wso2/product-is/issues/24775