### PR TITLE
Update the retry mechanism in threads

### DIFF
--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
@@ -18,6 +18,9 @@
 
 package org.wso2.identity.event.http.publisher.internal.service.impl;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,6 +44,7 @@ import org.wso2.identity.event.http.publisher.internal.util.HTTPAdapterUtil;
 import org.wso2.identity.event.http.publisher.internal.util.HTTPCorrelationLogUtils;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
@@ -55,7 +59,10 @@ import static org.wso2.identity.event.http.publisher.internal.util.HTTPCorrelati
 public class HTTPEventPublisherImpl implements EventPublisher {
 
     private static final Log log = LogFactory.getLog(HTTPEventPublisherImpl.class);
-    private List<Webhook> activeWebhooks;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
     @Override
     public String getAssociatedAdapter() {
@@ -67,14 +74,19 @@ public class HTTPEventPublisherImpl implements EventPublisher {
     public void publish(SecurityEventTokenPayload eventPayload, EventContext eventContext)
             throws EventPublisherException {
 
-        makeAsyncAPICall(eventPayload, eventContext);
+        try {
+            makeAsyncAPICall(eventPayload, eventContext);
+        } catch (WebhookMgtException e) {
+            throw new EventPublisherServerException(ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getMessage(),
+                    ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getDescription(), ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getCode(), e);
+        }
     }
 
     @Override
     public boolean canHandleEvent(EventContext eventContext) throws EventPublisherException {
 
         try {
-            activeWebhooks = HTTPAdapterDataHolder.getInstance().getWebhookManagementService()
+            final List<Webhook> activeWebhooks = HTTPAdapterDataHolder.getInstance().getWebhookManagementService()
                     .getActiveWebhooks(eventContext.getEventProfileName(), eventContext.getEventProfileVersion(),
                             eventContext.getEventUri(), eventContext.getTenantDomain());
             return !activeWebhooks.isEmpty();
@@ -84,72 +96,105 @@ public class HTTPEventPublisherImpl implements EventPublisher {
         }
     }
 
-    private void makeAsyncAPICall(SecurityEventTokenPayload eventPayload, EventContext eventContext) {
+    private void makeAsyncAPICall(SecurityEventTokenPayload eventPayload, EventContext eventContext)
+            throws WebhookMgtException {
+
+        // Freeze immutable per-publish values; reuse across retries.
+        final String correlationId = HTTPAdapterUtil.getCorrelationID(eventPayload);
+        final String tenantDomain = eventContext.getTenantDomain() + "-" + UUID.randomUUID();
+
+        final String eventProfileName = eventContext.getEventProfileName();
+        final String eventProfileUri = eventContext.getEventUri();
+        final String events = String.join(",", eventPayload.getEvents().keySet());
+
+        final String bodyJson;
+        try {
+            bodyJson = MAPPER.writeValueAsString(eventPayload);
+        } catch (JsonProcessingException e) {
+            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, null,
+                    HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT, DiagnosticLog.ResultStatus.FAILED,
+                    "Failed to serialize HTTP adapter payload.");
+            return;
+        }
+
+        final List<Webhook> activeWebhooks = HTTPAdapterDataHolder.getInstance().getWebhookManagementService()
+                .getActiveWebhooks(eventContext.getEventProfileName(), eventContext.getEventProfileVersion(),
+                        eventContext.getEventUri(), eventContext.getTenantDomain());
 
         for (Webhook webhook : activeWebhooks) {
-            String url = webhook.getEndpoint();
-            String secret = webhook.getSecret();
-            sendWithRetries(eventPayload, eventContext, url, secret,
+            final String url = webhook.getEndpoint();
+            final String secret = webhook.getSecret();
+
+            sendWithRetries(eventProfileName, eventProfileUri, events,
+                    bodyJson, correlationId, tenantDomain, url, secret,
                     HTTPAdapterDataHolder.getInstance().getClientManager().getMaxRetries());
         }
     }
 
-    private void sendWithRetries(SecurityEventTokenPayload eventPayload, EventContext eventContext,
-                                 String url, String secret, int retriesLeft) {
+    /**
+     * Retries always reuse the frozen snapshots; no shared mutable state is read here.
+     */
+    private void sendWithRetries(String eventProfileName, String eventProfileUri, String events, String bodyJson,
+                                 String correlationId, String tenantDomain, String url, String secret,
+                                 int retriesLeft) {
 
         ClientManager clientManager = HTTPAdapterDataHolder.getInstance().getClientManager();
+
         final HttpPost request;
         try {
-            request = clientManager.createHttpPost(url, eventPayload, secret);
+            request = clientManager.createHttpPost(url, bodyJson, secret);
         } catch (HTTPAdapterException e) {
-            printPublisherDiagnosticLog(eventContext, eventPayload, url,
+            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                     HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT, DiagnosticLog.ResultStatus.FAILED,
                     "Failed to construct HTTP request for HTTP adapter publish.");
             log.debug("Error constructing HTTP request for HTTP adapter publish. No retries will be attempted.", e);
             return;
         }
 
-        printPublisherDiagnosticLog(eventContext, eventPayload, url,
+        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                 HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT, DiagnosticLog.ResultStatus.SUCCESS,
                 "Publishing event data to endpoint.");
 
         final long requestStartTime = System.currentTimeMillis();
-        final String correlationId = HTTPAdapterUtil.getCorrelationID(eventPayload);
 
         CompletableFuture<HttpResponse> future = clientManager.executeAsync(request);
 
         future.whenCompleteAsync((response, throwable) -> {
             try {
                 PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(eventContext.getTenantDomain());
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+
                 if (StringUtils.isNotEmpty(correlationId)) {
                     MDC.put(CORRELATION_ID_MDC, correlationId);
                 }
-                MDC.put(TENANT_DOMAIN, eventContext.getTenantDomain());
+                MDC.put(TENANT_DOMAIN, tenantDomain);
+
                 if (throwable == null) {
                     int status = response.getStatusLine().getStatusCode();
                     if (status >= 200 && status < 300) {
                         handleResponseCorrelationLog(request, requestStartTime,
                                 HTTPCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
                                 String.valueOf(status), response.getStatusLine().getReasonPhrase());
-                        printPublisherDiagnosticLog(eventContext, eventPayload, url,
+                        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                                 HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                 DiagnosticLog.ResultStatus.SUCCESS, "Event data published to endpoint.");
                         log.debug("HTTP request completed. Response code: " + status +
-                                ", Endpoint: " + url + ", Event URI: " + eventContext.getEventUri());
+                                ", Endpoint: " + url + ", Event URI: " + eventProfileUri);
                     } else {
                         if (retriesLeft > 0) {
-                            printPublisherDiagnosticLog(eventContext, eventPayload, url,
+                            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                                     HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                     DiagnosticLog.ResultStatus.FAILED,
                                     "Publish attempt failed with status code: " + status +
                                             ". Retrying… (" + retriesLeft + " attempts left)");
-                            sendWithRetries(eventPayload, eventContext, url, secret, retriesLeft - 1);
+                            // Retry with the SAME snapshots
+                            sendWithRetries(eventProfileName, eventProfileUri, events,
+                                    bodyJson, correlationId, tenantDomain, url, secret, retriesLeft - 1);
                         } else {
                             handleResponseCorrelationLog(request, requestStartTime,
                                     HTTPCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
                                     String.valueOf(status), response.getStatusLine().getReasonPhrase());
-                            printPublisherDiagnosticLog(eventContext, eventPayload, url,
+                            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                                     HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                     DiagnosticLog.ResultStatus.FAILED,
                                     "Failed to publish event data to endpoint. Status code: " + status +
@@ -159,17 +204,19 @@ public class HTTPEventPublisherImpl implements EventPublisher {
                     }
                 } else {
                     if (retriesLeft > 0) {
-                        printPublisherDiagnosticLog(eventContext, eventPayload, url,
+                        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                                 HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                 DiagnosticLog.ResultStatus.FAILED,
                                 "Publish attempt failed due to exception. Retrying… (" +
                                         retriesLeft + " attempts left)");
-                        sendWithRetries(eventPayload, eventContext, url, secret, retriesLeft - 1);
+                        // Retry with the SAME snapshots
+                        sendWithRetries(eventProfileName, eventProfileUri, events,
+                                bodyJson, correlationId, tenantDomain, url, secret, retriesLeft - 1);
                     } else {
                         handleResponseCorrelationLog(request, requestStartTime,
                                 HTTPCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
                                 throwable.getMessage());
-                        printPublisherDiagnosticLog(eventContext, eventPayload, url,
+                        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events, url,
                                 HTTPAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                 DiagnosticLog.ResultStatus.FAILED,
                                 "Failed to publish event data to endpoint. Maximum retries reached.");

--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/util/HTTPAdapterUtil.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/util/HTTPAdapterUtil.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.identity.event.http.publisher.api.exception.HTTPAdapterClientException;
@@ -88,14 +87,15 @@ public class HTTPAdapterUtil {
     /**
      * Print diagnostic log for publisher operations.
      *
-     * @param eventContext Event context.
-     * @param eventPayload Event payload.
-     * @param endpoint     Endpoint URL.
-     * @param action       Action performed.
-     * @param status       Result status.
-     * @param message      Result message.
+     * @param eventProfileName Name of the event profile.
+     * @param eventProfileUri  URI of the event profile.
+     * @param events           Events published.
+     * @param endpoint         Endpoint URL.
+     * @param action           Action performed.
+     * @param status           Result status.
+     * @param message          Result message.
      */
-    public static void printPublisherDiagnosticLog(EventContext eventContext, SecurityEventTokenPayload eventPayload,
+    public static void printPublisherDiagnosticLog(String eventProfileName, String eventProfileUri, String events,
                                                    String endpoint, String action, DiagnosticLog.ResultStatus status,
                                                    String message) {
 
@@ -104,11 +104,10 @@ public class HTTPAdapterUtil {
                     HTTPAdapterConstants.LogConstants.HTTP_ADAPTER, action);
             diagnosticLogBuilder
                     .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.ENDPOINT, endpoint)
-                    .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.EVENT_URI, eventContext.getEventUri())
+                    .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.EVENT_URI, eventProfileUri)
                     .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.EVENT_PROFILE_NAME,
-                            eventContext.getEventProfileName())
-                    .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.EVENTS,
-                            String.join(",", eventPayload.getEvents().keySet()))
+                            eventProfileName)
+                    .inputParam(HTTPAdapterConstants.LogConstants.InputKeys.EVENTS, events)
                     .resultMessage(message)
                     .resultStatus(status)
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);

--- a/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/internal/ClientManagerTest.java
+++ b/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/internal/ClientManagerTest.java
@@ -78,25 +78,10 @@ public class ClientManagerTest {
 
         TestPayload payload = new TestPayload("mockFieldValue");
         String secret = "testSecret";
-        HttpPost post = clientManager.createHttpPost("http://mock-url.com", payload, secret);
+        HttpPost post = clientManager.createHttpPost("http://mock-url.com", payload.toString(), secret);
         Assert.assertNotNull(post);
         Assert.assertEquals(post.getMethod(), "POST");
         Assert.assertEquals(post.getURI().toString(), "http://mock-url.com");
-    }
-
-    @Test(expectedExceptions = HTTPAdapterException.class)
-    public void testCreateHttpPostException() throws HTTPAdapterException {
-
-        Object payload = new Object() {
-            @Override
-            public String toString() {
-
-                throw new RuntimeException("Simulated IOException trigger");
-            }
-        };
-
-        clientManager = new ClientManager();
-        clientManager.createHttpPost("http://mock-url.com", payload, null);
     }
 
     @Test

--- a/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.identity.event.http.publisher.internal.component.ClientManager;
@@ -34,6 +35,7 @@ import org.wso2.identity.event.http.publisher.internal.component.HTTPAdapterData
 import org.wso2.identity.event.http.publisher.internal.service.impl.HTTPEventPublisherImpl;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -122,6 +124,8 @@ public class HTTPEventPublisherImplTest {
                     .jti("jti-token")
                     .iat(System.currentTimeMillis())
                     .aud("audience")
+                    .events(Collections.singletonMap("event1", new EventPayload() {
+                    }))
                     .build();
 
             // Mock ClientManager behavior to simulate success

--- a/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
@@ -19,6 +19,7 @@
 package org.wso2.identity.event.http.publisher.service;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -132,7 +133,7 @@ public class HTTPEventPublisherImplTest {
             CompletableFuture<HttpResponse> future = CompletableFuture.completedFuture(mockHttpResponse);
             when(mockClientManager.executeAsync(any())).thenReturn(future);
             when(mockClientManager.createHttpPost(any(), any(), any())).thenReturn(
-                    mock(org.apache.http.client.methods.HttpPost.class));
+                    mock(HttpPost.class));
             when(mockClientManager.getAsyncCallbackExecutor()).thenReturn((Executor) Runnable::run);
 
             // Execute and verify no exception is thrown

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -18,8 +18,7 @@
 
 package org.wso2.identity.event.websubhub.publisher.internal;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -50,6 +49,7 @@ import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterExcept
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -320,29 +320,28 @@ public class ClientManager {
     /**
      * Create an HTTP POST request.
      *
-     * @param url     The URL for the HTTP POST request.
-     * @param payload The payload to include in the request body.
+     * @param url           The URL for the HTTP POST request.
+     * @param bodyJson      The JSON body for the request.
+     * @param correlationId The correlation ID for tracing.
      * @return A configured HttpPost instance.
      * @throws WebSubAdapterException If an error occurs while creating the request.
      */
-    public HttpPost createHttpPost(String url, Object payload) throws WebSubAdapterException {
+    public HttpPost createHttpPost(String url, String bodyJson, String correlationId)
+            throws WebSubAdapterException {
 
         HttpPost request = new HttpPost(url);
         request.setHeader(ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         request.setHeader(CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
-        request.setHeader(CORRELATION_ID_REQUEST_HEADER, WebSubHubAdapterUtil.getCorrelationID());
-
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-
+        if (StringUtils.isNotBlank(correlationId)) {
+            request.setHeader(CORRELATION_ID_REQUEST_HEADER, correlationId);
+        }
         try {
-            String jsonString = mapper.writeValueAsString(payload);
-            request.setEntity(new StringEntity(jsonString));
-        } catch (IOException e) {
+            if (bodyJson != null) {
+                request.setEntity(new StringEntity(bodyJson));
+            }
+        } catch (UnsupportedEncodingException e) {
             throw WebSubHubAdapterUtil.handleClientException(ERROR_PUBLISHING_EVENT_INVALID_PAYLOAD);
         }
-
         return request;
     }
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -42,7 +42,6 @@ import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterData
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
@@ -90,7 +89,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             final String bodyJson = MAPPER.writeValueAsString(eventPayload);
 
             final String correlationId = getCorrelationID(eventPayload);
-            final String tenantDomain = eventContext.getTenantDomain() + "-" + UUID.randomUUID();
+            final String tenantDomain = eventContext.getTenantDomain();
 
             final String eventProfileName = eventContext.getEventProfileName();
             final String eventProfileUri = eventContext.getEventUri();

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -18,6 +18,10 @@
 
 package org.wso2.identity.event.websubhub.publisher.service;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -38,16 +42,17 @@ import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterData
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage.ERROR_CODE_CONSTRUCTING_HUB_TOPIC;
 import static org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage.ERROR_CODE_TOPIC_EXISTS_CHECK;
-import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.CORRELATION_ID_REQUEST_HEADER;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.PUBLISH;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
+import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getCorrelationID;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.getWebSubBaseURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleResponseCorrelationLog;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.handleServerException;
@@ -59,6 +64,9 @@ import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterU
 public class WebSubEventPublisherImpl implements EventPublisher {
 
     private static final Log log = LogFactory.getLog(WebSubEventPublisherImpl.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
     @Override
     public String getAssociatedAdapter() {
@@ -71,14 +79,31 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             throws EventPublisherException {
 
         try {
-            makeAsyncAPICall(eventPayload, eventContext,
-                    constructHubTopic(eventContext.getEventUri(), eventContext.getEventProfileName(),
-                            eventContext.getEventProfileVersion(), eventContext.getTenantDomain()),
-                    getWebSubBaseURL());
-            log.debug("Event publishing to WebSubHub invoked.");
+            // Build immutable per-publish values.
+            final String topic = constructHubTopic(
+                    eventContext.getEventUri(),
+                    eventContext.getEventProfileName(),
+                    eventContext.getEventProfileVersion(),
+                    eventContext.getTenantDomain());
+
+            final String url = buildURL(topic, getWebSubBaseURL(), PUBLISH);
+            final String bodyJson = MAPPER.writeValueAsString(eventPayload);
+
+            final String correlationId = getCorrelationID(eventPayload);
+            final String tenantDomain = eventContext.getTenantDomain() + "-" + UUID.randomUUID();
+
+            final String eventProfileName = eventContext.getEventProfileName();
+            final String eventProfileUri = eventContext.getEventUri();
+            final String events = String.join(",", eventPayload.getEvents().keySet());
+
+            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId, tenantDomain, url,
+                    WebSubHubAdapterDataHolder.getInstance().getClientManager().getMaxRetries());
         } catch (WebSubAdapterException e) {
             throw handleServerException(ERROR_CODE_CONSTRUCTING_HUB_TOPIC, e,
                     WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME);
+        } catch (JsonProcessingException e) {
+            throw handleServerException(ERROR_CODE_CONSTRUCTING_HUB_TOPIC, e,
+                    "Error serializing event payload");
         }
     }
 
@@ -95,69 +120,68 @@ public class WebSubEventPublisherImpl implements EventPublisher {
         }
     }
 
-    private void makeAsyncAPICall(SecurityEventTokenPayload eventPayload, EventContext eventContext,
-                                  String topic, String webSubHubBaseUrl) throws WebSubAdapterException {
-
-        String url = buildURL(topic, webSubHubBaseUrl, PUBLISH);
-        printPublisherDiagnosticLog(eventContext, eventPayload,
-                WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT, DiagnosticLog.ResultStatus.SUCCESS,
-                "Publishing event data to WebSubHub.");
-
-        sendWithRetries(eventPayload, eventContext, url,
-                WebSubHubAdapterDataHolder.getInstance().getClientManager().getMaxRetries());
-    }
-
-    private void sendWithRetries(SecurityEventTokenPayload eventPayload, EventContext eventContext, String url,
-                                 int retriesLeft) {
+    private void sendWithRetries(String eventProfileName, String eventProfileUri, String events, String bodyJson,
+                                 String correlationId, String tenantDomain, String url, int retriesLeft) {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
+
         final HttpPost request;
         try {
-            request = clientManager.createHttpPost(url, eventPayload);
+            request = clientManager.createHttpPost(url, bodyJson, correlationId);
         } catch (WebSubAdapterException e) {
-            printPublisherDiagnosticLog(eventContext, eventPayload,
+            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                     WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT, DiagnosticLog.ResultStatus.FAILED,
                     "Failed to construct HTTP request for WebSubHub publish.");
-            log.debug("Error constructing HTTP request for WebSubHub publish. No retries will be attempted.", e);
+            log.warn("Failed to construct HTTP request for WebSubHub publish. No retries will be attempted.", e);
             return;
         }
 
+        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
+                WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
+                DiagnosticLog.ResultStatus.SUCCESS,
+                "Publishing event data to WebSubHub.");
+        log.debug("Event publishing to WebSubHub invoked.");
+
         final long requestStartTime = System.currentTimeMillis();
-        final String correlationId = request.getFirstHeader(CORRELATION_ID_REQUEST_HEADER).getValue();
 
         CompletableFuture<HttpResponse> future = clientManager.executeAsync(request);
-
         future.whenCompleteAsync((response, throwable) -> {
             try {
                 PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                        .setTenantDomain(eventContext.getTenantDomain());
-                MDC.put(CORRELATION_ID_MDC, correlationId);
-                MDC.put(TENANT_DOMAIN, eventContext.getTenantDomain());
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+                if (StringUtils.isNotBlank(correlationId)) {
+                    MDC.put(CORRELATION_ID_MDC, correlationId);
+                }
+                MDC.put(TENANT_DOMAIN, tenantDomain);
+
                 if (throwable == null) {
                     int status = response.getStatusLine().getStatusCode();
                     if (status >= 200 && status < 300) {
-                        handleAsyncResponse(response, eventPayload, request, requestStartTime, eventContext);
+                        handleAsyncResponse(eventProfileName, eventProfileUri, events, response, request,
+                                requestStartTime);
                     } else {
                         if (retriesLeft > 0) {
-                            printPublisherDiagnosticLog(eventContext, eventPayload,
+                            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                                     WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                     DiagnosticLog.ResultStatus.FAILED,
                                     "Publish attempt failed with status code: " + status +
                                             ". Retrying… (" + retriesLeft + " attempts left)");
-                            sendWithRetries(eventPayload, eventContext, url, retriesLeft - 1);
+                            log.debug("Publish attempt failed with status code: " + status +
+                                    ". Retrying… (" + retriesLeft + " attempts left)");
+                            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId,
+                                    tenantDomain, url, retriesLeft - 1);
                         } else {
                             handleResponseCorrelationLog(request, requestStartTime,
                                     WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
                                     String.valueOf(status),
                                     response.getStatusLine().getReasonPhrase());
-                            printPublisherDiagnosticLog(eventContext, eventPayload,
+                            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                                     WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                     DiagnosticLog.ResultStatus.FAILED,
                                     "Failed to publish event data to WebSubHub. Status code: " + status +
                                             ". Maximum retries reached.");
-                            log.error(
-                                    "Failed to publish event data to websubhub: " + url + ". Maximum retries reached.");
+                            log.error("Failed to publish event data to WebSubHub: " + url +
+                                    ". Maximum retries reached.");
                             try {
                                 if (response.getEntity() != null) {
                                     String body = EntityUtils.toString(response.getEntity());
@@ -167,7 +191,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                                             ". Response entity is null.");
                                 }
                             } catch (IOException e) {
-                                printPublisherDiagnosticLog(eventContext, eventPayload,
+                                printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                                         WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                         DiagnosticLog.ResultStatus.FAILED,
                                         "Error while reading WebSubHub event publisher");
@@ -177,49 +201,53 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                     }
                 } else {
                     if (retriesLeft > 0) {
-                        printPublisherDiagnosticLog(eventContext, eventPayload,
+                        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                                 WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                 DiagnosticLog.ResultStatus.FAILED,
                                 "Publish attempt failed due to exception. Retrying… (" +
                                         retriesLeft + " attempts left)");
-                        sendWithRetries(eventPayload, eventContext, url, retriesLeft - 1);
+                        log.debug("Publish attempt failed due to exception. Retrying… (" +
+                                retriesLeft + " attempts left)", throwable);
+                        sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId,
+                                tenantDomain, url, retriesLeft - 1);
                     } else {
                         handleResponseCorrelationLog(request, requestStartTime,
                                 WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
                                 throwable.getMessage());
-                        printPublisherDiagnosticLog(eventContext, eventPayload,
+                        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                                 WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                                 DiagnosticLog.ResultStatus.FAILED,
                                 "Failed to publish event data to WebSubHub. Maximum retries reached.");
-                        log.error("Failed to publish event data to websubhub: " + url + ". Maximum retries reached.");
+                        log.error("Failed to publish event data to WebSubHub: " + url +
+                                ". Maximum retries reached.");
                     }
                 }
             } finally {
-                MDC.remove(CORRELATION_ID_MDC);
+                if (StringUtils.isNotBlank(correlationId)) {
+                    MDC.remove(CORRELATION_ID_MDC);
+                }
                 MDC.remove(TENANT_DOMAIN);
                 PrivilegedCarbonContext.endTenantFlow();
             }
         }, clientManager.getAsyncCallbackExecutor());
     }
 
-    private static void handleAsyncResponse(HttpResponse response, SecurityEventTokenPayload eventPayload,
-                                            HttpPost request,
-                                            long requestStartTime,
-                                            EventContext eventContext) {
+    private static void handleAsyncResponse(String eventProfileName, String eventProfileUri, String events,
+                                            HttpResponse response, HttpPost request, long requestStartTime) {
 
         int responseCode = response.getStatusLine().getStatusCode();
         String responsePhrase = response.getStatusLine().getReasonPhrase();
+
         log.debug("WebSubHub request completed. Response code: " + responseCode);
 
         handleResponseCorrelationLog(request, requestStartTime,
                 WebSubHubCorrelationLogUtils.RequestStatus.COMPLETED.getStatus(),
                 String.valueOf(responseCode), responsePhrase);
 
-        printPublisherDiagnosticLog(eventContext, eventPayload,
+        printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                 WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                 DiagnosticLog.ResultStatus.SUCCESS,
                 "Event data published to WebSubHub. Status code: " + responseCode);
-
         try {
             if (response.getEntity() != null) {
                 log.debug("Response data: " + EntityUtils.toString(response.getEntity()));
@@ -227,7 +255,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                 log.debug("Response entity is null.");
             }
         } catch (IOException e) {
-            printPublisherDiagnosticLog(eventContext, eventPayload,
+            printPublisherDiagnosticLog(eventProfileName, eventProfileUri, events,
                     WebSubHubAdapterConstants.LogConstants.ActionIDs.PUBLISH_EVENT,
                     DiagnosticLog.ResultStatus.FAILED,
                     "Error while reading WebSubHub event publisher response.");

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_SUBSCRIBING_TO_TOPIC;
@@ -149,8 +148,7 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
 
-        HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null,
-                Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse(""));
+        HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null, MDC.get(CORRELATION_ID_MDC));
         httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
 
         List<BasicNameValuePair> params = new ArrayList<>();

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImpl.java
@@ -27,6 +27,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.MDC;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
 import org.wso2.carbon.identity.subscription.management.api.model.SubscriptionStatus;
 import org.wso2.carbon.identity.subscription.management.api.model.WebhookSubscriptionRequest;
@@ -43,7 +44,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_SUBSCRIBING_TO_TOPIC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_CALLBACK;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.HUB_MODE;
@@ -146,7 +149,8 @@ public class WebSubEventSubscriberImpl implements EventSubscriber {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
 
-        HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null);
+        HttpPost httpPost = clientManager.createHttpPost(webSubHubBaseUrl, null,
+                Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse(""));
         httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
 
         List<BasicNameValuePair> params = new ArrayList<>();

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -43,7 +43,6 @@ import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogU
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
@@ -130,8 +129,7 @@ public class WebSubTopicManagerImpl implements TopicManager {
 
         int attempt = 0;
         while (true) {
-            HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null,
-                    Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse(""));
+            HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null, MDC.get(CORRELATION_ID_MDC));
             httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
 
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImpl.java
@@ -28,6 +28,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.util.EntityUtils;
+import org.slf4j.MDC;
 import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
 import org.wso2.carbon.utils.DiagnosticLog;
@@ -42,7 +43,9 @@ import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogU
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_DEREGISTERING_HUB_TOPIC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
@@ -127,7 +130,8 @@ public class WebSubTopicManagerImpl implements TopicManager {
 
         int attempt = 0;
         while (true) {
-            HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null);
+            HttpPost httpPost = clientManager.createHttpPost(topicMgtUrl, null,
+                    Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse(""));
             httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
 
             WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(httpPost);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtil.java
@@ -27,12 +27,10 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
-import org.slf4j.MDC;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherServerException;
-import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
@@ -48,9 +46,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB;
@@ -77,14 +73,9 @@ public class WebSubHubAdapterUtil {
      *
      * @return Correlation ID.
      */
-    public static String getCorrelationID() {
+    public static String getCorrelationID(SecurityEventTokenPayload eventTokenPayload) {
 
-        String correlationID = MDC.get(CORRELATION_ID_MDC);
-        if (StringUtils.isBlank(correlationID)) {
-            correlationID = UUID.randomUUID().toString();
-            MDC.put(CORRELATION_ID_MDC, correlationID);
-        }
-        return correlationID;
+        return eventTokenPayload.getRci();
     }
 
     /**
@@ -215,24 +206,23 @@ public class WebSubHubAdapterUtil {
     /**
      * Print diagnostic log for publisher operations.
      *
-     * @param eventContext Event context.
-     * @param eventPayload Event payload.
-     * @param action       Action performed.
-     * @param status       Result status.
-     * @param message      Result message.
+     * @param eventProfileName Event profile name.
+     * @param eventProfileUri  Event profile URI.
+     * @param events           Events.
+     * @param action           Action performed.
+     * @param status           Result status.
+     * @param message          Result message.
      */
-    public static void printPublisherDiagnosticLog(EventContext eventContext, SecurityEventTokenPayload eventPayload,
+    public static void printPublisherDiagnosticLog(String eventProfileName, String eventProfileUri, String events,
                                                    String action, DiagnosticLog.ResultStatus status, String message) {
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
                     WebSubHubAdapterConstants.LogConstants.WEB_SUB_HUB_ADAPTER, action);
             diagnosticLogBuilder
-                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENT_URI, eventContext.getEventUri())
-                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENT_PROFILE_NAME,
-                            eventContext.getEventProfileName())
-                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENTS,
-                            String.join(",", eventPayload.getEvents().keySet()))
+                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENT_URI, eventProfileUri)
+                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENT_PROFILE_NAME, eventProfileName)
+                    .inputParam(WebSubHubAdapterConstants.LogConstants.InputKeys.EVENTS, events)
                     .resultMessage(message)
                     .resultStatus(status)
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManagerTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManagerTest.java
@@ -66,24 +66,10 @@ public class ClientManagerTest {
     public void testCreateHttpPost() throws WebSubAdapterException {
 
         TestPayload payload = new TestPayload("mockFieldValue");
-        HttpPost post = clientManager.createHttpPost("http://mock-url.com", payload);
+        HttpPost post =
+                clientManager.createHttpPost("http://mock-url.com", String.valueOf(payload), "test-correlation-id");
         Assert.assertNotNull(post);
         Assert.assertEquals(post.getMethod(), "POST");
-    }
-
-    @Test(expectedExceptions = WebSubAdapterException.class)
-    public void testCreateHttpPostException() throws WebSubAdapterException {
-
-        Object payload = new Object() {
-            @Override
-            public String toString() {
-
-                throw new RuntimeException("Simulated IOException trigger");
-            }
-        };
-
-        ClientManager clientManager = new ClientManager();
-        clientManager.createHttpPost("http://mock-url.com", payload);
     }
 
     @AfterClass

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
@@ -35,6 +36,7 @@ import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
 import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterDataHolder;
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -113,7 +115,8 @@ public class WebSubEventPublisherImplTest {
             mockedAdapterUtil.when(WebSubHubAdapterUtil::getWebSubBaseURL)
                     .thenReturn("http://mock-websub-hub.com");
             mockedAdapterUtil.when(
-                            () -> WebSubHubAdapterUtil.printPublisherDiagnosticLog(any(), any(), any(), any(), any()))
+                            () -> WebSubHubAdapterUtil
+                                    .printPublisherDiagnosticLog(any(), any(), any(), any(), any(), any()))
                     .then(invocation -> null);
 
             // Mock ClientManager.getMaxRetries()
@@ -130,6 +133,8 @@ public class WebSubEventPublisherImplTest {
                     .jti("jti-token")
                     .iat(System.currentTimeMillis())
                     .aud("audience")
+                    .events(Collections.singletonMap("event1", new EventPayload() {
+                    }))
                     .build();
 
             // Mock HttpPost and its header
@@ -141,7 +146,7 @@ public class WebSubEventPublisherImplTest {
             // Mock ClientManager behavior to simulate success
             CompletableFuture<HttpResponse> future = CompletableFuture.completedFuture(mockHttpResponse);
             when(mockClientManager.executeAsync(any())).thenReturn(future);
-            when(mockClientManager.createHttpPost(any(), any())).thenReturn(mockHttpPost);
+            when(mockClientManager.createHttpPost(any(), any(), any())).thenReturn(mockHttpPost);
             when(mockClientManager.getAsyncCallbackExecutor()).thenReturn((Executor) Runnable::run);
 
             // Execute and verify no exception is thrown

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventSubscriberImplTest.java
@@ -103,7 +103,7 @@ public class WebSubEventSubscriberImplTest {
                 .build();
 
         HttpPost mockHttpPost = mock(HttpPost.class);
-        when(mockClientManager.createHttpPost(any(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.createHttpPost(any(), any(), any())).thenReturn(mockHttpPost);
         when(mockClientManager.executeSubscriberRequest(any())).thenReturn(mockHttpResponse);
 
         StatusLine mockStatusLine = mock(StatusLine.class);
@@ -130,7 +130,7 @@ public class WebSubEventSubscriberImplTest {
                 .build();
 
         HttpPost mockHttpPost = mock(HttpPost.class);
-        when(mockClientManager.createHttpPost(any(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.createHttpPost(any(), any(), any())).thenReturn(mockHttpPost);
         when(mockClientManager.executeSubscriberRequest(any())).thenReturn(mockHttpResponse);
 
         StatusLine mockStatusLine = mock(StatusLine.class);

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubTopicManagerImplTest.java
@@ -125,7 +125,7 @@ public class WebSubTopicManagerImplTest {
                                 any(HttpPost.class), anyLong(), anyString(), anyString(), anyString()))
                 .thenAnswer(invocation -> null);
 
-        when(mockClientManager.createHttpPost(anyString(), any())).thenReturn(mockHttpPost);
+        when(mockClientManager.createHttpPost(anyString(), any(), any())).thenReturn(mockHttpPost);
         when(mockClientManager.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
         when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
         when(mockHttpResponse.getEntity()).thenReturn(mockEntity);
@@ -172,7 +172,7 @@ public class WebSubTopicManagerImplTest {
 
         when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
         webSubTopicManager.registerTopic("test-topic", "carbon.super");
-        verify(mockClientManager).createHttpPost(anyString(), any());
+        verify(mockClientManager).createHttpPost(anyString(), any(), any());
         verify(mockClientManager).execute(any(HttpPost.class));
     }
 
@@ -181,7 +181,7 @@ public class WebSubTopicManagerImplTest {
 
         when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
         webSubTopicManager.deregisterTopic("test-topic", "carbon.super");
-        verify(mockClientManager).createHttpPost(anyString(), any());
+        verify(mockClientManager).createHttpPost(anyString(), any(), any());
         verify(mockClientManager).execute(any(HttpPost.class));
         mockedStaticUtil.verify(WebSubHubAdapterUtil::getWebSubBaseURL);
         mockedStaticUtil.verify(

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtilTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/util/WebSubHubAdapterUtilTest.java
@@ -20,6 +20,7 @@ package org.wso2.identity.event.websubhub.publisher.util;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterClientException;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterServerException;
@@ -32,7 +33,14 @@ public class WebSubHubAdapterUtilTest {
     @Test
     public void testGetCorrelationID() {
 
-        String correlationId = WebSubHubAdapterUtil.getCorrelationID();
+        SecurityEventTokenPayload payload = SecurityEventTokenPayload.builder()
+                .iss("issuer")
+                .jti("jti-token")
+                .iat(System.currentTimeMillis())
+                .aud("audience")
+                .rci("test-correlation-id")
+                .build();
+        String correlationId = WebSubHubAdapterUtil.getCorrelationID(payload);
         Assert.assertNotNull(correlationId, "Correlation ID should not be null.");
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request refactors the HTTP event publishing logic to improve immutability, reliability, and clarity in the async event publishing flow. The main changes include moving JSON serialization responsibility out of `ClientManager`, ensuring immutable per-publish values for retries, and simplifying diagnostic logging. Additionally, relevant test cases and imports have been updated accordingly.

**Refactoring and Reliability Improvements:**

* The `ClientManager.createHttpPost` method now accepts a pre-serialized JSON string instead of a generic payload object, removing internal JSON serialization logic and related dependencies. This change makes the method simpler and more predictable. [[1]](diffhunk://#diff-6c5977ec47e16715e36401f68f0dc5539c9d48c056167b9aefb6fd3c30f5bc32L21-L22) [[2]](diffhunk://#diff-6c5977ec47e16715e36401f68f0dc5539c9d48c056167b9aefb6fd3c30f5bc32L196-L218)
* In `HTTPEventPublisherImpl`, immutable "snapshot" variables (such as correlation ID, tenant domain, event details, and payload JSON) are frozen at the start of the publish operation and reused across retries. This prevents shared mutable state issues and ensures consistent retry behavior.
* The retry logic in `sendWithRetries` has been updated to use these immutable snapshots, improving reliability and making the retry process more transparent. [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L87-R197) [[2]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L162-R219)

**Logging and Diagnostics:**

* The `printPublisherDiagnosticLog` utility now takes explicit event profile information and event lists as parameters, instead of requiring the full event context and payload. This change streamlines logging and decouples it from internal data structures. [[1]](diffhunk://#diff-1871e01d895a50132e5930b6690808bbf848dba00ca141e385a68dae473e9019L91-R98) [[2]](diffhunk://#diff-1871e01d895a50132e5930b6690808bbf848dba00ca141e385a68dae473e9019L107-R110)

**Code Cleanup and Test Updates:**

* Unused imports and unnecessary fields (such as the `activeWebhooks` instance variable) have been removed for clarity. [[1]](diffhunk://#diff-6c5977ec47e16715e36401f68f0dc5539c9d48c056167b9aefb6fd3c30f5bc32L21-L22) [[2]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L58-R65)
* Test cases for `ClientManager` have been updated to use pre-serialized JSON strings, and obsolete exception tests have been removed to match the new method signatures.
* Imports and minor code style issues have been addressed in both implementation and test files. [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R21-R23) [[2]](diffhunk://#diff-3edd42dad12af2ede8d2756e6816f5ce924c720c529aa5d100c5fee3921bc043R30-R38)

These changes collectively improve the maintainability, safety, and clarity of the HTTP event publishing mechanism.