### PR TITLE
Improve the fault-tolerant behaviour of publisher

### DIFF
--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/component/ClientManager.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/component/ClientManager.java
@@ -116,7 +116,9 @@ public class ClientManager {
 
             // Custom handler that logs when the queue is full and discards the task.
             RejectedExecutionHandler handler = (r, executor) -> {
-                LOG.warn("Async callback queue is full; discarding task of publishing events.");
+                LOG.error(
+                        "Async callback queue is full; discarding task of publishing events. " +
+                                "Please attend immediately.");
                 // the task is silently dropped
             };
 

--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/constant/HTTPAdapterConstants.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/constant/HTTPAdapterConstants.java
@@ -82,8 +82,8 @@ public class HTTPAdapterConstants {
 
             public static final String ENDPOINT = "endpoint";
             public static final String EVENTS = "events";
-            public static final String EVENT_URI = "event uri";
-            public static final String EVENT_PROFILE_NAME = "event profile name";
+            public static final String EVENT_URI = "eventUri";
+            public static final String EVENT_PROFILE_NAME = "eventProfileName";
         }
     }
 

--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
@@ -164,7 +164,7 @@ public class HTTPEventPublisherImpl implements EventPublisher {
             try {
                 MDC.clear();
                 PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
 
                 if (StringUtils.isNotEmpty(correlationId)) {
                     MDC.put(CORRELATION_ID_MDC, correlationId);

--- a/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/internal/ClientManagerTest.java
+++ b/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/internal/ClientManagerTest.java
@@ -34,6 +34,7 @@ import org.wso2.identity.event.http.publisher.internal.component.HTTPAdapterData
 import org.wso2.identity.event.http.publisher.internal.config.HTTPAdapterConfiguration;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -145,6 +146,21 @@ public class ClientManagerTest {
         callbackCaptor.getValue().cancelled();
 
         Assert.assertTrue(future.isCancelled());
+    }
+
+    @Test
+    public void testGetAsyncCallbackExecutor() {
+        Executor executor = clientManager.getAsyncCallbackExecutor();
+        Assert.assertNotNull(executor, "Async callback executor should not be null");
+    }
+
+    @Test
+    public void testGetMaxRetries() {
+        HTTPAdapterConfiguration mockConfiguration = HTTPAdapterDataHolder.getInstance().getAdapterConfiguration();
+        // Set up the mock to return a specific value
+        when(mockConfiguration.getMaxRetries()).thenReturn(3);
+        int maxRetries = clientManager.getMaxRetries();
+        Assert.assertEquals(maxRetries, 3, "Max retries should match the configured value");
     }
 
     @AfterClass

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -201,8 +201,8 @@ public class WebSubHubAdapterConstants {
             public static final String EVENTS = "events";
             public static final String CHANNEL = "channel";
             public static final String ENDPOINT = "endpoint";
-            public static final String EVENT_URI = "event uri";
-            public static final String EVENT_PROFILE_NAME = "event profile name";
+            public static final String EVENT_URI = "eventUri";
+            public static final String EVENT_PROFILE_NAME = "eventProfileName";
         }
     }
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/ClientManager.java
@@ -134,7 +134,9 @@ public class ClientManager {
 
             // Custom handler that logs when the queue is full and discards the task.
             RejectedExecutionHandler handler = (r, executor) -> {
-                LOG.warn("Async callback queue is full; discarding task of publishing events.");
+                LOG.error(
+                        "Async callback queue is full; discarding task of publishing events. " +
+                                "Please attend immediately.");
                 // the task is silently dropped
             };
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -148,7 +148,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             try {
                 MDC.clear();
                 PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
                 if (StringUtils.isNotBlank(correlationId)) {
                     MDC.put(CORRELATION_ID_MDC, correlationId);
                 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -266,7 +266,9 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                     "Error while reading WebSubHub event publisher response.");
             log.debug("Error while reading WebSubHub event publisher response.", e);
         } finally {
-            EntityUtils.consumeQuietly(response.getEntity());
+            if (response.getEntity() != null) {
+                EntityUtils.consumeQuietly(response.getEntity());
+            }
         }
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -146,6 +146,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
         CompletableFuture<HttpResponse> future = clientManager.executeAsync(request);
         future.whenCompleteAsync((response, throwable) -> {
             try {
+                MDC.clear();
                 PrivilegedCarbonContext.startTenantFlow();
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
                 if (StringUtils.isNotBlank(correlationId)) {
@@ -195,6 +196,10 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                                         DiagnosticLog.ResultStatus.FAILED,
                                         "Error while reading WebSubHub event publisher");
                                 log.debug("Error while reading WebSubHub response.", e);
+                            } finally {
+                                if (response.getEntity() != null) {
+                                    EntityUtils.consumeQuietly(response.getEntity());
+                                }
                             }
                         }
                     }
@@ -227,6 +232,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                 }
                 MDC.remove(TENANT_DOMAIN);
                 PrivilegedCarbonContext.endTenantFlow();
+                MDC.clear();
             }
         }, clientManager.getAsyncCallbackExecutor());
     }
@@ -259,6 +265,8 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                     DiagnosticLog.ResultStatus.FAILED,
                     "Error while reading WebSubHub event publisher response.");
             log.debug("Error while reading WebSubHub event publisher response.", e);
+        } finally {
+            EntityUtils.consumeQuietly(response.getEntity());
         }
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request focuses on improving error handling, resource cleanup, and logging in the HTTP and WebSubHub event publishers. The changes ensure that thread-local context is properly cleared, HTTP response entities are always consumed to prevent resource leaks, and logging is more prominent when the async callback queue is full. Additionally, new unit tests have been added to improve test coverage.

**Error handling and resource cleanup:**

* Ensured that `MDC.clear()` is called at the beginning and end of async callbacks in both `HTTPEventPublisherImpl` and `WebSubEventPublisherImpl` to prevent thread-local context leaks. [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R165) [[2]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R230-R238) [[3]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR149) [[4]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR235)
* Added logic to consume HTTP response entities quietly using `EntityUtils.consumeQuietly` after processing responses, both in normal and exceptional flows, to prevent resource leaks. [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R230-R238) [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR199-R202) [[3]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR268-R269)

**Logging improvements:**

* Changed the log level from `warn` to `error` and updated the message when the async callback queue is full in both `ClientManager` classes, making the issue more visible and actionable. [[1]](diffhunk://#diff-6c5977ec47e16715e36401f68f0dc5539c9d48c056167b9aefb6fd3c30f5bc32L119-R121) [[2]](diffhunk://#diff-8cc82d8505da57e61796f96f2b3d47c3d2bf1b91e65aa3fbb34c72bfdb31ee2eL137-R139)

**Testing improvements:**

* Added unit tests for `getAsyncCallbackExecutor` and `getMaxRetries` in `ClientManagerTest` to ensure proper configuration and executor retrieval.
* Added missing import for `Executor` in the test file.

**Dependency updates:**

* Added import for `EntityUtils` in `HTTPEventPublisherImpl` to support response entity consumption.