### PR TITLE
Copy MDC to Async thread

### DIFF
--- a/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.http.publisher/src/main/java/org/wso2/identity/event/http/publisher/internal/service/impl/HTTPEventPublisherImpl.java
@@ -45,8 +45,10 @@ import org.wso2.identity.event.http.publisher.internal.util.HTTPAdapterUtil;
 import org.wso2.identity.event.http.publisher.internal.util.HTTPCorrelationLogUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Collections.emptyMap;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.TENANT_DOMAIN;
 import static org.wso2.identity.event.http.publisher.internal.constant.ErrorMessage.ERROR_ACTIVE_WEBHOOKS_RETRIEVAL;
@@ -102,6 +104,9 @@ public class HTTPEventPublisherImpl implements EventPublisher {
         final String eventProfileUri = eventContext.getEventUri();
         final String events = String.join(",", eventPayload.getEvents().keySet());
 
+        final Map<String, String> copiedMDCSnapshot =
+                MDC.getCopyOfContextMap() != null ? MDC.getCopyOfContextMap() : emptyMap();
+
         final String bodyJson;
         try {
             bodyJson = MAPPER.writeValueAsString(eventPayload);
@@ -127,7 +132,7 @@ public class HTTPEventPublisherImpl implements EventPublisher {
             final String secret = webhook.getSecret();
 
             sendWithRetries(eventProfileName, eventProfileUri, events,
-                    bodyJson, correlationId, tenantDomain, url, secret,
+                    bodyJson, copiedMDCSnapshot, correlationId, tenantDomain, url, secret,
                     HTTPAdapterDataHolder.getInstance().getClientManager().getMaxRetries());
         }
     }
@@ -136,7 +141,8 @@ public class HTTPEventPublisherImpl implements EventPublisher {
      * Retries always reuse the frozen snapshots; no shared mutable state is read here.
      */
     private void sendWithRetries(String eventProfileName, String eventProfileUri, String events, String bodyJson,
-                                 String correlationId, String tenantDomain, String url, String secret,
+                                 Map<String, String> mdcSnapshot, String correlationId, String tenantDomain, String url,
+                                 String secret,
                                  int retriesLeft) {
 
         ClientManager clientManager = HTTPAdapterDataHolder.getInstance().getClientManager();
@@ -163,13 +169,15 @@ public class HTTPEventPublisherImpl implements EventPublisher {
         future.whenCompleteAsync((response, throwable) -> {
             try {
                 MDC.clear();
-                PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
-
-                if (StringUtils.isNotEmpty(correlationId)) {
+                if (mdcSnapshot != null && !mdcSnapshot.isEmpty()) {
+                    MDC.setContextMap(mdcSnapshot);
+                }
+                if (StringUtils.isNotBlank(correlationId)) {
                     MDC.put(CORRELATION_ID_MDC, correlationId);
                 }
                 MDC.put(TENANT_DOMAIN, tenantDomain);
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
 
                 if (throwable == null) {
                     int status = response.getStatusLine().getStatusCode();
@@ -190,8 +198,8 @@ public class HTTPEventPublisherImpl implements EventPublisher {
                                     "Publish attempt failed with status code: " + status +
                                             ". Retrying… (" + retriesLeft + " attempts left)");
                             // Retry with the SAME snapshots
-                            sendWithRetries(eventProfileName, eventProfileUri, events,
-                                    bodyJson, correlationId, tenantDomain, url, secret, retriesLeft - 1);
+                            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, mdcSnapshot,
+                                    correlationId, tenantDomain, url, secret, retriesLeft - 1);
                         } else {
                             handleResponseCorrelationLog(request, requestStartTime,
                                     HTTPCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
@@ -212,8 +220,8 @@ public class HTTPEventPublisherImpl implements EventPublisher {
                                 "Publish attempt failed due to exception. Retrying… (" +
                                         retriesLeft + " attempts left)");
                         // Retry with the SAME snapshots
-                        sendWithRetries(eventProfileName, eventProfileUri, events,
-                                bodyJson, correlationId, tenantDomain, url, secret, retriesLeft - 1);
+                        sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, mdcSnapshot, correlationId,
+                                tenantDomain, url, secret, retriesLeft - 1);
                     } else {
                         handleResponseCorrelationLog(request, requestStartTime,
                                 HTTPCorrelationLogUtils.RequestStatus.FAILED.getStatus(),

--- a/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.http.publisher/src/test/java/org/wso2/identity/event/http/publisher/service/HTTPEventPublisherImplTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
@@ -61,12 +62,14 @@ public class HTTPEventPublisherImplTest {
     private HttpResponse mockHttpResponse;
 
     private MockedStatic<HTTPAdapterDataHolder> mockedStaticDataHolder;
+    private static MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
 
     @BeforeClass
     public void setUp() throws Exception {
 
         mocks = MockitoAnnotations.openMocks(this);
         adapterService = spy(new HTTPEventPublisherImpl());
+        mockIdentityTenantUtil();
 
         mockedStaticDataHolder = mockStatic(HTTPAdapterDataHolder.class);
         HTTPAdapterDataHolder mockDataHolder = mock(HTTPAdapterDataHolder.class);
@@ -143,5 +146,18 @@ public class HTTPEventPublisherImplTest {
             verify(mockClientManager, times(2)).executeAsync(any());
             verify(mockClientManager, times(2)).createHttpPost(any(), any(), any());
         }
+    }
+
+    /**
+     * Mocks the IdentityTenantUtil.
+     */
+    private static void mockIdentityTenantUtil() {
+
+        if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {
+            mockedStaticIdentityTenantUtil.close();
+        }
+        mockedStaticIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantedSessionsEnabled()).thenReturn(false);
+        when(IdentityTenantUtil.getTenantId("test-tenant")).thenReturn(1);
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -42,8 +42,10 @@ import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterData
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Collections.emptyMap;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage.ERROR_CODE_CONSTRUCTING_HUB_TOPIC;
@@ -95,7 +97,11 @@ public class WebSubEventPublisherImpl implements EventPublisher {
             final String eventProfileUri = eventContext.getEventUri();
             final String events = String.join(",", eventPayload.getEvents().keySet());
 
-            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId, tenantDomain, url,
+            final Map<String, String> copiedMDCSnapshot =
+                    MDC.getCopyOfContextMap() != null ? MDC.getCopyOfContextMap() : emptyMap();
+
+            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, copiedMDCSnapshot, correlationId,
+                    tenantDomain, url,
                     WebSubHubAdapterDataHolder.getInstance().getClientManager().getMaxRetries());
         } catch (WebSubAdapterException e) {
             throw handleServerException(ERROR_CODE_CONSTRUCTING_HUB_TOPIC, e,
@@ -120,7 +126,8 @@ public class WebSubEventPublisherImpl implements EventPublisher {
     }
 
     private void sendWithRetries(String eventProfileName, String eventProfileUri, String events, String bodyJson,
-                                 String correlationId, String tenantDomain, String url, int retriesLeft) {
+                                 Map<String, String> mdcSnapshot, String correlationId, String tenantDomain, String url,
+                                 int retriesLeft) {
 
         ClientManager clientManager = WebSubHubAdapterDataHolder.getInstance().getClientManager();
 
@@ -147,12 +154,15 @@ public class WebSubEventPublisherImpl implements EventPublisher {
         future.whenCompleteAsync((response, throwable) -> {
             try {
                 MDC.clear();
-                PrivilegedCarbonContext.startTenantFlow();
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                if (mdcSnapshot != null && !mdcSnapshot.isEmpty()) {
+                    MDC.setContextMap(mdcSnapshot);
+                }
                 if (StringUtils.isNotBlank(correlationId)) {
                     MDC.put(CORRELATION_ID_MDC, correlationId);
                 }
                 MDC.put(TENANT_DOMAIN, tenantDomain);
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
 
                 if (throwable == null) {
                     int status = response.getStatusLine().getStatusCode();
@@ -168,8 +178,8 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                                             ". Retrying… (" + retriesLeft + " attempts left)");
                             log.debug("Publish attempt failed with status code: " + status +
                                     ". Retrying… (" + retriesLeft + " attempts left)");
-                            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId,
-                                    tenantDomain, url, retriesLeft - 1);
+                            sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, mdcSnapshot,
+                                    correlationId, tenantDomain, url, retriesLeft - 1);
                         } else {
                             handleResponseCorrelationLog(request, requestStartTime,
                                     WebSubHubCorrelationLogUtils.RequestStatus.FAILED.getStatus(),
@@ -212,7 +222,7 @@ public class WebSubEventPublisherImpl implements EventPublisher {
                                         retriesLeft + " attempts left)");
                         log.debug("Publish attempt failed due to exception. Retrying… (" +
                                 retriesLeft + " attempts left)", throwable);
-                        sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, correlationId,
+                        sendWithRetries(eventProfileName, eventProfileUri, events, bodyJson, mdcSnapshot, correlationId,
                                 tenantDomain, url, retriesLeft - 1);
                     } else {
                         handleResponseCorrelationLog(request, requestStartTime,

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
@@ -67,12 +68,14 @@ public class WebSubEventPublisherImplTest {
     private HttpResponse mockHttpResponse;
 
     private MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
+    private static MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
 
     @BeforeClass
     public void setUp() throws Exception {
 
         mocks = MockitoAnnotations.openMocks(this);
         adapterService = spy(new WebSubEventPublisherImpl());
+        mockIdentityTenantUtil();
 
         mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
         WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
@@ -155,5 +158,18 @@ public class WebSubEventPublisherImplTest {
             // Verify interactions
             verify(mockClientManager, times(1)).executeAsync(any());
         }
+    }
+
+    /**
+     * Mocks the IdentityTenantUtil.
+     */
+     private static void mockIdentityTenantUtil() {
+
+        if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {
+            mockedStaticIdentityTenantUtil.close();
+        }
+        mockedStaticIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantedSessionsEnabled()).thenReturn(false);
+        when(IdentityTenantUtil.getTenantId("test-tenant")).thenReturn(1);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request improves the reliability and correctness of event publishing in both the HTTP and WebSubHub publishers by ensuring that the Mapped Diagnostic Context (MDC) is properly captured and restored across asynchronous API calls and retries. This prevents loss of logging context and avoids shared mutable state issues when publishing events asynchronously.

**MDC context handling improvements:**

* Captured a snapshot of the MDC context (`MDC.getCopyOfContextMap()`) before initiating async API calls, ensuring that each retry uses the same logging context and preventing shared mutable state issues. (`HTTPEventPublisherImpl.java` [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R107-R109) `WebSubEventPublisherImpl.java` [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL98-R104)
* Modified the `sendWithRetries` method signatures to accept the MDC snapshot as a parameter, so that each retry invocation restores the correct context. (`HTTPEventPublisherImpl.java` [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L139-R145) [[2]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L193-R202) [[3]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L215-R224); `WebSubEventPublisherImpl.java` [[4]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL123-R130) [[5]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL171-R182) [[6]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL215-R225)
* Updated the logic in the async completion handler to restore the MDC context from the snapshot before setting additional context values and starting tenant flows, ensuring log correlation is maintained for each event. (`HTTPEventPublisherImpl.java` [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701L166-R180); `WebSubEventPublisherImpl.java` [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dL150-R165)

**General codebase consistency:**

* Applied these MDC handling improvements consistently across both HTTP and WebSubHub event publisher implementations, reducing the risk of context leaks and improving maintainability. (`HTTPEventPublisherImpl.java` [[1]](diffhunk://#diff-c94483d2d09661e5d87007126c4d48216b055484dc74d0f0dd039fc9f8086701R48-R51); `WebSubEventPublisherImpl.java` [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR45-R48)

These changes collectively ensure that asynchronous event publishing and retries maintain the correct logging and tenant context, improving traceability and robustness.
