### PR TITLE
Bump nimbus-jose-jwt version to 10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,8 +446,8 @@
         <compiler-target.version>1.8</compiler-target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <nimbusds.version>7.9.0.wso2v1</nimbusds.version>
-        <nimbusds.osgi.version.range>[7.0.0,8.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>10.3.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[10.3.0.wso2v1,11.0.0)</nimbusds.osgi.version.range>
         <json-smart.version>2.4.7</json-smart.version>
 
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
### Purpose
> The nimbus library needs to be bumped in the product due. 

### Related Issue/s 
- https://github.com/wso2/product-is/issues/23582