### PR TITLE
Add active webhooks check to the canHandleEvent() of WebSubEventPublisher

### DIFF
--- a/components/org.wso2.identity.event.websubhub.publisher/pom.xml
+++ b/components/org.wso2.identity.event.websubhub.publisher/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -74,6 +74,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.webhook.metadata</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.webhook.management</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -158,6 +162,8 @@
                             org.wso2.carbon.identity.event.publisher.api.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.webhook.metadata.api.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.webhook.management.api.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.json.simple.parser; version="${com.googlecode.json-simple.wso2.version.range}",
                             org.wso2.carbon.identity.organization.management.service.*;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -133,7 +133,9 @@ public class WebSubHubAdapterConstants {
                 "Error while resolving organization ID for tenant: %s."),
         ERROR_CONSTRUCTING_HUB_TOPIC("65015", "Error constructing WebSubHub topic.",
                 "Error constructing WebSubHub topic for channel: %s, event profile version: %s, " +
-                        "tenant domain: %s.");
+                        "tenant domain: %s."),
+        ERROR_ACTIVE_WEBHOOKS_RETRIEVAL("65016", "Error while retrieving active webhooks.",
+                "Error while retrieving active webhooks for event URI: %s");
 
         private static final String WEB_SUB_ADAPTER_ERROR_CODE_PREFIX = "WEBSUB-";
         private final String code;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/constant/WebSubHubAdapterConstants.java
@@ -135,7 +135,7 @@ public class WebSubHubAdapterConstants {
                 "Error constructing WebSubHub topic for channel: %s, event profile version: %s, " +
                         "tenant domain: %s."),
         ERROR_ACTIVE_WEBHOOKS_RETRIEVAL("65016", "Error while retrieving active webhooks.",
-                "Error while retrieving active webhooks for event URI: %s");
+                "Error while retrieving active webhooks for event URI: %s.");
 
         private static final String WEB_SUB_ADAPTER_ERROR_CODE_PREFIX = "WEBSUB-";
         private final String code;

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterDataHolder.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,6 +20,7 @@ package org.wso2.identity.event.websubhub.publisher.internal;
 
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
+import org.wso2.carbon.identity.webhook.management.api.service.WebhookManagementService;
 import org.wso2.carbon.identity.webhook.metadata.api.service.EventAdapterMetadataService;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
 
@@ -37,6 +38,7 @@ public class WebSubHubAdapterDataHolder {
     private OrganizationManager organizationManager;
     private TopicManagementService topicManagementService;
     private EventAdapterMetadataService eventAdapterMetadataService;
+    private WebhookManagementService webhookManagementService;
 
     private WebSubHubAdapterDataHolder() {
 
@@ -125,5 +127,25 @@ public class WebSubHubAdapterDataHolder {
     public void setEventAdapterMetadataService(EventAdapterMetadataService eventAdapterMetadataService) {
 
         this.eventAdapterMetadataService = eventAdapterMetadataService;
+    }
+
+    /**
+     * Get the webhook management service.
+     *
+     * @return WebhookManagementService instance.
+     */
+    public WebhookManagementService getWebhookManagementService() {
+
+        return webhookManagementService;
+    }
+
+    /**
+     * Set the webhook management service.
+     *
+     * @param webhookManagementService WebhookManagementService instance.
+     */
+    public void setWebhookManagementService(WebhookManagementService webhookManagementService) {
+
+        this.webhookManagementService = webhookManagementService;
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/internal/WebSubHubAdapterServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.organization.management.service.OrganizationMana
 import org.wso2.carbon.identity.subscription.management.api.service.EventSubscriber;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManager;
+import org.wso2.carbon.identity.webhook.management.api.service.WebhookManagementService;
 import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.service.EventAdapterMetadataService;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
@@ -163,5 +164,22 @@ public class WebSubHubAdapterServiceComponent {
 
         WebSubHubAdapterDataHolder.getInstance().setEventAdapterMetadataService(null);
         log.debug("EventAdapterMetadataService unset in WebSubHubAdapterDataHolder bundle.");
+    }
+
+    @Reference(
+            name = "webhook.management.service.component",
+            service = WebhookManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetWebhookManagementService"
+    )
+    protected void setWebhookManagementService(WebhookManagementService webhookManagementService) {
+
+        WebSubHubAdapterDataHolder.getInstance().setWebhookManagementService(webhookManagementService);
+    }
+
+    protected void unsetWebhookManagementService(WebhookManagementService webhookManagementService) {
+
+        WebSubHubAdapterDataHolder.getInstance().setWebhookManagementService(null);
     }
 }

--- a/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/main/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,10 +31,13 @@ import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
+import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherServerException;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.carbon.identity.event.publisher.api.service.EventPublisher;
 import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
+import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
@@ -43,6 +46,7 @@ import org.wso2.identity.event.websubhub.publisher.internal.WebSubHubAdapterData
 import org.wso2.identity.event.websubhub.publisher.util.WebSubHubCorrelationLogUtils;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -52,6 +56,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage.ERROR_CODE_CONSTRUCTING_HUB_TOPIC;
 import static org.wso2.carbon.identity.event.publisher.api.constant.ErrorMessage.ERROR_CODE_TOPIC_EXISTS_CHECK;
+import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.ErrorMessages.ERROR_ACTIVE_WEBHOOKS_RETRIEVAL;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.PUBLISH;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.buildURL;
 import static org.wso2.identity.event.websubhub.publisher.util.WebSubHubAdapterUtil.constructHubTopic;
@@ -118,13 +123,25 @@ public class WebSubEventPublisherImpl implements EventPublisher {
     @Override
     public boolean canHandleEvent(EventContext eventContext) throws EventPublisherException {
 
+        // Skip publishing when no active webhooks are subscribed to this event. A WebSubHub topic can exist without
+        // any subscribed webhook resources, in which case publishing would result in a wasted hub round-trip.
         try {
+            List<Webhook> activeWebhooks = WebSubHubAdapterDataHolder.getInstance().getWebhookManagementService()
+                    .getActiveWebhooks(eventContext.getEventProfileName(), eventContext.getEventProfileVersion(),
+                            eventContext.getEventUri(), eventContext.getTenantDomain());
+            if (activeWebhooks == null || activeWebhooks.isEmpty()) {
+                return false;
+            }
             return WebSubHubAdapterDataHolder.getInstance().getTopicManagementService()
                     .isTopicExists(eventContext.getEventUri(), eventContext.getEventProfileName(),
                             eventContext.getEventProfileVersion(), eventContext.getTenantDomain());
         } catch (TopicManagementException e) {
             throw handleServerException(ERROR_CODE_TOPIC_EXISTS_CHECK, e,
                     WebSubHubAdapterConstants.WEB_SUB_HUB_ADAPTER_NAME);
+        } catch (WebhookMgtException e) {
+            throw new EventPublisherServerException(ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getCode(),
+                    ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getMessage(),
+                    String.format(ERROR_ACTIVE_WEBHOOKS_RETRIEVAL.getDescription(), eventContext.getEventUri()), e);
         }
     }
 

--- a/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
+++ b/components/org.wso2.identity.event.websubhub.publisher/src/test/java/org/wso2/identity/event/websubhub/publisher/service/WebSubEventPublisherImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,13 +24,20 @@ import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
+import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherServerException;
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
+import org.wso2.carbon.identity.topic.management.api.exception.TopicManagementException;
+import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
+import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
+import org.wso2.carbon.identity.webhook.management.api.service.WebhookManagementService;
 import org.wso2.identity.event.websubhub.publisher.config.WebSubAdapterConfiguration;
 import org.wso2.identity.event.websubhub.publisher.exception.WebSubAdapterException;
 import org.wso2.identity.event.websubhub.publisher.internal.ClientManager;
@@ -42,12 +49,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.wso2.identity.event.websubhub.publisher.constant.WebSubHubAdapterConstants.Http.CORRELATION_ID_REQUEST_HEADER;
 
 /**
@@ -67,6 +79,10 @@ public class WebSubEventPublisherImplTest {
     @Mock
     private HttpResponse mockHttpResponse;
 
+    private WebSubHubAdapterDataHolder mockDataHolder;
+    private WebhookManagementService mockWebhookManagementService;
+    private TopicManagementService mockTopicManagementService;
+
     private MockedStatic<WebSubHubAdapterDataHolder> mockedStaticDataHolder;
     private static MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
 
@@ -78,7 +94,7 @@ public class WebSubEventPublisherImplTest {
         mockIdentityTenantUtil();
 
         mockedStaticDataHolder = mockStatic(WebSubHubAdapterDataHolder.class);
-        WebSubHubAdapterDataHolder mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
+        mockDataHolder = mock(WebSubHubAdapterDataHolder.class);
         mockedStaticDataHolder.when(WebSubHubAdapterDataHolder::getInstance).thenReturn(mockDataHolder);
 
         when(mockDataHolder.getClientManager()).thenReturn(mockClientManager);
@@ -90,6 +106,21 @@ public class WebSubEventPublisherImplTest {
                 mock(org.wso2.carbon.identity.organization.management.service.OrganizationManager.class);
         when(mockDataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
         when(mockOrgManager.resolveOrganizationId(any())).thenReturn("mock-org-id");
+
+        mockWebhookManagementService = mock(WebhookManagementService.class);
+        mockTopicManagementService = mock(TopicManagementService.class);
+        when(mockDataHolder.getWebhookManagementService()).thenReturn(mockWebhookManagementService);
+        when(mockDataHolder.getTopicManagementService()).thenReturn(mockTopicManagementService);
+    }
+
+    @BeforeMethod
+    public void resetCanHandleEventMocks() {
+
+        // Mocks are class-scoped, so clear invocation history so each test can assert
+        // call counts independently of preceding tests.
+        if (mockWebhookManagementService != null && mockTopicManagementService != null) {
+            clearInvocations(mockWebhookManagementService, mockTopicManagementService);
+        }
     }
 
     @AfterClass
@@ -158,6 +189,85 @@ public class WebSubEventPublisherImplTest {
             // Verify interactions
             verify(mockClientManager, times(1)).executeAsync(any());
         }
+    }
+
+    @Test
+    public void testCanHandleEventReturnsFalseWhenActiveWebhooksNull() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any())).thenReturn(null);
+
+        assertFalse(adapterService.canHandleEvent(buildEventContext()));
+        // Topic existence must not be queried when no active webhooks are present.
+        verify(mockTopicManagementService, never()).isTopicExists(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testCanHandleEventReturnsFalseWhenActiveWebhooksEmpty() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        assertFalse(adapterService.canHandleEvent(buildEventContext()));
+        verify(mockTopicManagementService, never()).isTopicExists(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testCanHandleEventReturnsTrueWhenWebhooksExistAndTopicExists() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any()))
+                .thenReturn(Collections.singletonList(mock(Webhook.class)));
+        when(mockTopicManagementService.isTopicExists(any(), any(), any(), any())).thenReturn(true);
+
+        assertTrue(adapterService.canHandleEvent(buildEventContext()));
+        verify(mockTopicManagementService, times(1))
+                .isTopicExists("test-uri", "WSO2", "v1", "test-tenant");
+    }
+
+    @Test
+    public void testCanHandleEventReturnsFalseWhenWebhooksExistButTopicMissing() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any()))
+                .thenReturn(Collections.singletonList(mock(Webhook.class)));
+        when(mockTopicManagementService.isTopicExists(any(), any(), any(), any())).thenReturn(false);
+
+        assertFalse(adapterService.canHandleEvent(buildEventContext()));
+    }
+
+    @Test
+    public void testCanHandleEventWrapsWebhookMgtExceptionAsServerException() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any()))
+                .thenThrow(new WebhookMgtException("boom"));
+
+        try {
+            adapterService.canHandleEvent(buildEventContext());
+            org.testng.Assert.fail("Expected EventPublisherServerException");
+        } catch (EventPublisherServerException e) {
+            assertEquals(e.getErrorCode(), "WEBSUB-65016");
+            // Topic existence must not be checked once the webhook lookup itself failed.
+            verify(mockTopicManagementService, never()).isTopicExists(any(), any(), any(), any());
+        }
+    }
+
+    @Test(expectedExceptions = EventPublisherException.class)
+    public void testCanHandleEventWrapsTopicManagementException() throws Exception {
+
+        when(mockWebhookManagementService.getActiveWebhooks(any(), any(), any(), any()))
+                .thenReturn(Collections.singletonList(mock(Webhook.class)));
+        when(mockTopicManagementService.isTopicExists(any(), any(), any(), any()))
+                .thenThrow(new TopicManagementException("code", "msg", "desc"));
+
+        adapterService.canHandleEvent(buildEventContext());
+    }
+
+    private EventContext buildEventContext() {
+
+        return EventContext.builder()
+                .tenantDomain("test-tenant")
+                .eventProfileName("WSO2")
+                .eventProfileVersion("v1")
+                .eventUri("test-uri")
+                .build();
     }
 
     /**


### PR DESCRIPTION


This pull request introduces support for integrating with the `WebhookManagementService` to optimize event publishing in the WebSubHub publisher component. The main improvement is that events are now only published if there are active webhooks subscribed to the event, reducing unnecessary processing. Several supporting changes have been made to enable this integration and improve error handling.

**Integration with Webhook Management Service:**

* Added `org.wso2.carbon.identity.webhook.management` as a dependency in `pom.xml` and updated OSGi imports to include its API. [[1]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R78-R81) [[2]](diffhunk://#diff-9263265065af81feb6e02bd627cc577c51c1f7a97197a090dee6fab0983342d3R166-R167)
* Updated the `WebSubHubAdapterDataHolder` singleton to store and expose a reference to `WebhookManagementService`, including new getter and setter methods. [[1]](diffhunk://#diff-33f4081441b818948a88a05a049f4c2e332a3ec800bd9b7f6b37266a07fdfbb5R23) [[2]](diffhunk://#diff-33f4081441b818948a88a05a049f4c2e332a3ec800bd9b7f6b37266a07fdfbb5R41) [[3]](diffhunk://#diff-33f4081441b818948a88a05a049f4c2e332a3ec800bd9b7f6b37266a07fdfbb5R131-R150)
* Modified `WebSubHubAdapterServiceComponent` to bind and unbind the `WebhookManagementService` using OSGi annotations, ensuring the service is available at runtime. [[1]](diffhunk://#diff-4e0f8e9093345247632daacc1f9e8643b9271ddd6ba8f2b3f049344ae3361f21R36) [[2]](diffhunk://#diff-4e0f8e9093345247632daacc1f9e8643b9271ddd6ba8f2b3f049344ae3361f21R168-R184)

**Event Publishing Optimization:**

* Updated `WebSubEventPublisherImpl` so that events are only published if there are active webhooks subscribed to the event. This is done by checking for active webhooks before checking if the topic exists. [[1]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR34-R40) [[2]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR49) [[3]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR59) [[4]](diffhunk://#diff-00bdfa40ab93a10290d02b2c04f78e33beb058af2facbc56198bffca0ad78d7dR126-R144)

**Error Handling Improvements:**

* Added a new error message `ERROR_ACTIVE_WEBHOOKS_RETRIEVAL` to `WebSubHubAdapterConstants` for handling failures when retrieving active webhooks.
* Enhanced exception handling in `WebSubEventPublisherImpl` to throw a specific server exception if retrieving active webhooks fails.


